### PR TITLE
Typo on Class description

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -4,7 +4,7 @@ namespace Valitron;
 /**
  * Validation Class
  *
- * Validates input against certian criteria
+ * Validates input against certain criteria
  *
  * @package Valitron
  * @author Vance Lucas <vance@vancelucas.com>


### PR DESCRIPTION
Just a typo on the class description.
