### PR TITLE
add global static lang support and sample to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ if($v->validate()) {
 }
 ```
 
+Setting language and language dir globally:
+
+```php
+
+// boot or config file
+
+use Valitron\Validator as V; 
+
+V::langDir(__DIR__.'/validator_lang'); // always set langDir before lang.
+V::lang('ar');
+
+```
+
+
+
 ## Built-in Validation Rules
 
  * `required` - Required field

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -29,7 +29,7 @@ class Validator
     /**
      *  Setup validation
      */
-    public function __construct($data, $fields = array(), $lang = 'en', $langDir = null)
+    public function __construct($data, $fields = array(), $lang = null, $langDir = null)
     {
         // Allows filtering of used input fields against optional second array of field names allowed
         // This is useful for limiting raw $_POST or $_GET data to only known fields
@@ -39,17 +39,13 @@ class Validator
             }
         }
 
-        // Only load language files if language or directory has changed
-        if($lang !== static::$_lang || $langDir !== static::$_langDir) {
-            // Set language directory for loading language files
-            if($langDir === null) {
-                $langDir = dirname(dirname(__DIR__)) . '/lang';
-            }
-            static::langDir($langDir);
+        // set lang in the follow order: constructor param, static::$_lang, defaul to en
+        $lang = $lang ?: static::$_lang ?: 'en';
+        // set langDir in the follow order: constructor param, static::$_langDir, default to package lang dir
+        $langDir = $langDir ?: static::$_langDir ?: dirname(dirname(__DIR__)) . '/lang';
 
-            // Set language for error messages
-            static::lang($lang);
-        }
+        static::langDir($langDir);
+        static::lang($lang);
     }
 
     /**

--- a/tests/Valitron/StaticLangTest.php
+++ b/tests/Valitron/StaticLangTest.php
@@ -1,0 +1,59 @@
+<?php
+use Valitron\Validator;
+
+class StaticLangTest extends \PHPUnit_Framework_TestCase
+{
+	public function tearDown()
+	{
+		$this->resetProperty('_lang');
+		$this->resetProperty('_langDir');
+		$this->resetProperty('_ruleMessages', array());
+	}
+
+	protected function resetProperty($name, $value = null)
+	{
+		$prop = new ReflectionProperty('Valitron\Validator', $name);
+		$prop->setAccessible(true);
+		$prop->setValue($value);
+		$prop->setAccessible(false);
+	}
+
+	protected function getLangDir()
+	{
+		return __DIR__.'/../../lang';
+	}
+
+	/**
+	 * Lang defined statically should not be overrided by constructor default
+	 */
+    public function testLangDefinedStatically()
+    {
+    	$lang = 'ar';
+    	Validator::lang($lang);
+    	$validator = new Validator(array());
+    	$this->assertEquals($lang, Validator::lang());
+	}
+
+	/**
+	 * LangDir defined statically should not be overrided by constructor default
+	 */
+    public function testLangDirDefinedStatically()
+    {
+    	$langDir = $this->getLangDir();
+    	Validator::langDir($langDir);
+    	$validator = new Validator(array());
+    	$this->assertEquals($langDir, Validator::langDir());
+	}
+
+	public function testDefaultLangShouldBeEn()
+	{
+		$validator = new Validator(array());
+		$this->assertEquals('en', Validator::lang());
+	}
+
+	public function testDefaultLangDirShouldBePackageLangDir()
+	{
+		$validator = new Validator(array());
+		$this->assertEquals(realpath($this->getLangDir()), realpath(Validator::langDir()));
+	}
+}


### PR DESCRIPTION
The lang constructor param was overriding the static property _lang, when defined before constructing.
