### PR TITLE
Fixed issue with validating decimals with Min/Max rules

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -224,7 +224,7 @@ class Validator
      */
     protected function validateMin($field, $value, $params)
     {
-        return $value >= $params[0];
+        return !(bccomp($params[0], $value, 14) == 1);
     }
 
     /**
@@ -238,7 +238,7 @@ class Validator
      */
     protected function validateMax($field, $value, $params)
     {
-        return $value <= $params[0];
+        return !(bccomp($value, $params[0], 14) == 1);
     }
 
     /**

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -152,12 +152,20 @@ class ValidateTest extends BaseTestCase
         $v = new Validator(array('num' => 5));
         $v->rule('min', 'num', 2);
         $this->assertTrue($v->validate());
+
+        $v = new Validator(array('num' => 5));
+        $v->rule('min', 'num', 5);
+        $this->assertTrue($v->validate());
     }
 
-    public function testMinValidDecimal()
+    public function testMinValidFloat()
     {
         $v = new Validator(array('num' => 0.9));
         $v->rule('min', 'num', 0.5);
+        $this->assertTrue($v->validate());
+
+        $v = new Validator(array('num' => 1 - 0.81));
+        $v->rule('min', 'num', 0.19);
         $this->assertTrue($v->validate());
     }
 
@@ -168,7 +176,7 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
-    public function testMinInvalidDecimal()
+    public function testMinInvalidFloat()
     {
         $v = new Validator(array('num' => 0.5));
         $v->rule('min', 'num', 0.9);
@@ -180,12 +188,20 @@ class ValidateTest extends BaseTestCase
         $v = new Validator(array('num' => 5));
         $v->rule('max', 'num', 6);
         $this->assertTrue($v->validate());
+
+        $v = new Validator(array('num' => 5));
+        $v->rule('max', 'num', 5);
+        $this->assertTrue($v->validate());
     }
 
-    public function testMaxValidDecimal()
+    public function testMaxValidFloat()
     {
         $v = new Validator(array('num' => 0.4));
         $v->rule('max', 'num', 0.5);
+        $this->assertTrue($v->validate());
+
+        $v = new Validator(array('num' => 1 - 0.83));
+        $v->rule('max', 'num', 0.17);
         $this->assertTrue($v->validate());
     }
 
@@ -196,7 +212,7 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
-    public function testMaxInvalidDecimal()
+    public function testMaxInvalidFloat()
     {
         $v = new Validator(array('num' => 0.9));
         $v->rule('max', 'num', 0.5);


### PR DESCRIPTION
The expected outcome of the below is `true` but was producing `false`.

``` php
$v = new Validator(array('num' => 0.9));
$v->rule('min', 'num', 0.5);
var_dump($v->validate()); // bool(false)
```

This was being caused by casting the `$value` to an `int`.

``` php
$x = (int) 0.9;
var_dump($x); // int(0)
```
