### PR TITLE
Run validation is field is non-null instead of truthy. Fixes #70

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -698,7 +698,7 @@ class Validator
                 $value = isset($this->_fields[$field]) ? $this->_fields[$field] : null;
 
                 // Don't validate if the field is not required and the value is empty
-                if ($v['rule'] !== 'required' && !$this->hasRule('required', $field) && $value == '') {
+                if ($v['rule'] !== 'required' && !$this->hasRule('required', $field) && (! isset($value) || $value === '')) {
                     continue;
                 }
 

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -727,6 +727,20 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
+    public function testZeroStillTriggersValidation()
+    {
+        $v = new Validator(array('test' => 0));
+        $v->rule('min', 'test', 1);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testFalseStillTriggersValidation()
+    {
+        $v = new Validator(array('test' => FALSE));
+        $v->rule('min', 'test', 5);
+        $this->assertFalse($v->validate());
+    }
+
     public function testCreditCardValid()
     {
         $visa         = array(4539511619543489, 4532949059629052, 4024007171194938, 4929646403373269, 4539135861690622);


### PR DESCRIPTION
This change ensures that validation is still run on fields whose values are zero or FALSE.
