### PR TITLE
Fixes #64. Updated validateDateFormat

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -517,7 +517,7 @@ class Validator
     {
         $parsed = date_parse_from_format($params[0], $value);
 
-        return $parsed['error_count'] === 0;
+        return $parsed['error_count'] === 0 && $parsed['warning_count'] === 0;
     }
 
     /**

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -449,6 +449,10 @@ class ValidateTest extends BaseTestCase
         $v = new Validator(array('date' => 'no thanks'));
         $v->rule('dateFormat', 'date', 'Y-m-d');
         $this->assertFalse($v->validate());
+
+        $v = new Validator(array('date' => '2013-27-01'));
+        $v->rule('dateFormat', 'date', 'Y-m-d');
+        $this->assertFalse($v->validate());
     }
 
     public function testDateBeforeValid()


### PR DESCRIPTION
Currently the below will validate as `true` which is incorrect due to the 27th month.

```
$v = new Validator(array('date' => '2013-27-01'));
$v->rule('dateFormat', 'date', 'Y-m-d');
```

`date_parse_from_format` which is used in `validateDateFormat` returns with an `error_count` of `0` and a `warning_count` of `1`. The warning is `The parsed date was invalid`.

I've updated `validateDateFormat` to check that both `error_count` and `warning_count` are equal to `0`.
