### PR TITLE
Validation of nested arrays, closes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ if($v->validate()) {
 }
 ```
 
+You may use dot syntax to access members of multi-dimensional arrays,
+and an asterisk to validate each member of an array:
+
+```php
+$v = new Valitron\Validator(array('settings' => array(
+    array('threshold' => 50),
+    array('threshold' => 90)
+)));
+$v->rule('max', 'settings.*.threshold', 100);
+if($v->validate()) {
+    echo "Yay! We're all good!";
+} else {
+    // Errors
+    print_r($v->errors());
+}
+```
+
 Setting language and language dir globally:
 
 ```php
@@ -92,6 +109,7 @@ V::lang('ar');
  * `accepted` - Checkbox or Radio must be accepted (yes, on, 1, true)
  * `numeric` - Must be numeric
  * `integer` - Must be integer number
+ * `array` - Must be array
  * `length` - String must be certain length
  * `lengthBetween` - String must be between given lengths
  * `lengthMin` - String must be greater than given length

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -273,6 +273,93 @@ class ValidateTest extends BaseTestCase
         $this->assertTrue($v->validate());
     }
 
+    public function testArrayValid()
+    {
+        $v = new Validator(array('colors' => array('yellow')));
+        $v->rule('array', 'colors');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testAssocArrayValid()
+    {
+        $v = new Validator(array('settings' => array('color' => 'yellow')));
+        $v->rule('array', 'settings');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testArrayInvalid()
+    {
+        $v = new Validator(array('colors' => 'yellow'));
+        $v->rule('array', 'colors');
+        $this->assertFalse($v->validate());
+    }
+
+    public function testArrayAccess()
+    {
+        $v = new Validator(array('settings' => array('enabled' => true)));
+        $v->rule('boolean', 'settings.enabled');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testArrayAccessInvalid()
+    {
+        $v = new Validator(array('settings' => array('threshold' => 500)));
+        $v->rule('max', 'settings.threshold', 100);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testForeachArrayAccess()
+    {
+        $v = new Validator(array('settings' => array(
+            array('enabled' => true),
+            array('enabled' => true)
+        )));
+        $v->rule('boolean', 'settings.*.enabled');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testForeachArrayAccessInvalid()
+    {
+        $v = new Validator(array('settings' => array(
+            array('threshold' => 50),
+            array('threshold' => 500)
+        )));
+        $v->rule('max', 'settings.*.threshold', 100);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testNestedForeachArrayAccess()
+    {
+        $v = new Validator(array('widgets' => array(
+            array('settings' => array(
+                array('enabled' => true),
+                array('enabled' => true)
+            )),
+            array('settings' => array(
+                array('enabled' => true),
+                array('enabled' => true)
+            ))
+        )));
+        $v->rule('boolean', 'widgets.*.settings.*.enabled');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testNestedForeachArrayAccessInvalid()
+    {
+        $v = new Validator(array('widgets' => array(
+            array('settings' => array(
+                array('threshold' => 50),
+                array('threshold' => 90)
+            )),
+            array('settings' => array(
+                array('threshold' => 40),
+                array('threshold' => 500)
+            ))
+        )));
+        $v->rule('max', 'widgets.*.settings.*.threshold', 100);
+        $this->assertFalse($v->validate());
+    }
+
     public function testInInvalid()
     {
         $v = new Validator(array('color' => 'yellow'));


### PR DESCRIPTION
This pull request extends Valitron to allow validation of multidimensional arrays, as well as validating all members of an array by passing an asterisk. I've also added an "array" rule that validates that a field is an array.

Examples:

``` php
$v->rule('array', 'examples');
$v->rule('array', 'examples.*');
$v->rule('boolean', 'examples.*.enabled');
```
