### PR TITLE
The retarded but correct, in_array() loose comparison.

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -350,14 +350,14 @@ class Validator
      * @internal param array $fields
      * @return bool
      */
-    protected function validateIn($field, $value, $params)
+    protected function validateIn($field, $value, $params, $strict = false)
     {
         $isAssoc = array_values($params[0]) !== $params[0];
         if ($isAssoc) {
             $params[0] = array_keys($params[0]);
         }
 
-        return in_array($value, $params[0]);
+        return in_array($value, $params[0], $strict);
     }
 
     /**


### PR DESCRIPTION
Hi, I have added a strict flag as an argument since anyone who wishes a strict comparison shall have the option, and btw in_array without strict is sort of "useless" in most cases, IMHO.

heres why i say so.
http://php.net/manual/en/function.in-array.php#106319
http://php.net/manual/en/function.in-array.php#114117
