### PR TITLE
Added config object and messageFieldFilter option

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -63,7 +63,9 @@ class Validator
      * @var array
      */
     protected static $_config = array(
-        'messageFieldFilter' => 'titleCase',
+        'messageFieldFilter' => function($field, $msg) {
+            return str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $msg);
+        },
     );
 
     /**
@@ -1024,11 +1026,7 @@ class Validator
             }
         } else {
             $filter = self::config('messageFieldFilter');
-            if ($filter == 'titleCase') {
-                $msg = str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $msg);
-            } else if ($filter == 'none') {
-                $msg = str_replace('{field}', $field, $msg);
-            }
+            $msg = $filter($field, $msg);
         }
 
         return $msg;

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -63,9 +63,7 @@ class Validator
      * @var array
      */
     protected static $_config = array(
-        'messageFieldFilter' => function($field, $msg) {
-            return str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $msg);
-        },
+        'messageFieldFilter' => array(__NAMESPACE__ .'\Validator', 'defaultMessageFieldFilter'),
     );
 
     /**
@@ -102,6 +100,10 @@ class Validator
         } else {
             throw new \InvalidArgumentException("fail to load language file '$langFile'");
         }
+    }
+
+    static protected function defaultMessageFieldFilter($field, $msg) {
+        return str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $msg);
     }
 
     /**
@@ -1025,8 +1027,15 @@ class Validator
                 }
             }
         } else {
-            $filter = self::config('messageFieldFilter');
-            $msg = $filter($field, $msg);
+            $msg = call_user_func(self::config('messageFieldFilter'), $field, $msg);
+
+            //$msg = $filter($field, $msg);
+            // $filter = self::config('messageFieldFilter');
+            // if ($filter == 'titleCase') {
+            //     $msg = str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $msg);
+            // } else if ($filter == 'none') {
+            //     $msg = str_replace('{field}', $field, $msg);
+            // }
         }
 
         return $msg;

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -62,6 +62,13 @@ class Validator
     /**
      * @var array
      */
+    protected static $_config = array(
+        'messageFieldFilter' => 'titleCase',
+    );
+
+    /**
+     * @var array
+     */
     protected $validUrlPrefixes = array('http://', 'https://', 'ftp://');
 
     /**
@@ -93,6 +100,19 @@ class Validator
         } else {
             throw new \InvalidArgumentException("fail to load language file '$langFile'");
         }
+    }
+
+    /**
+     * Get/set configuration values
+     *
+     * @param  string $lang
+     * @return string
+     */
+    public static function config($name, $value = null)
+    {
+        if ($value === null) return isset(self::$_config[$name]) ? self::$_config[$name] : null;
+
+        self::$_config[$name] = $value;
     }
 
     /**
@@ -1003,7 +1023,12 @@ class Validator
                 }
             }
         } else {
-            $msg = str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $msg);
+            $filter = self::config('messageFieldFilter');
+            if ($filter == 'titleCase') {
+                $msg = str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $msg);
+            } else if ($filter == 'none') {
+                $msg = str_replace('{field}', $field, $msg);
+            }
         }
 
         return $msg;


### PR DESCRIPTION
Hello,

I really like this validation library, it is simple and yet covers most cases. I think it would be useful though to make it more configurable though, so that it can be tweaked to business needs.

For this purpose, I suggest adding a config object that, over time, could be extended with various properties. For a start, I have added a "messageFieldFilter" option. This is to allow customizing how the {field} variable is displayed in the error messages (I have added "none" option, for no filter). I have field names such as "xref_ug_x_2" and it is confusing to have it converted to "Xref Ug X 2" in the message so it would be useful to disable this.

Please have a look at the pull request and let me know what you think.

Thanks,

Laurent
