### PR TITLE
validateUrlActive(): check host part of URL for correct DNS records

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -452,9 +452,9 @@ class Validator
     {
         foreach ($this->validUrlPrefixes as $prefix) {
             if (strpos($value, $prefix) !== false) {
-                $url = str_replace($prefix, '', strtolower($value));
-
-                return checkdnsrr($url);
+                $host = parse_url(strtolower($value), PHP_URL_HOST);
+                
+                return checkdnsrr($host, 'A') || checkdnsrr($host, 'AAAA') || checkdnsrr($host, 'CNAME');
             }
         }
 


### PR DESCRIPTION
validateUrlActive() calls checkdnsrr() which by default looks only for MX records, and passes the whole tail part of the URL after the prefix. It should isolate the host and check for A, AAAA or CNAME DNS records.