### PR TITLE
type check

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -244,7 +244,7 @@ class Validator
             return $length >= $params[0] && $length <= $params[1];
         }
         // Length same
-        return $length == $params[0];
+        return ($length !== false) && $length == $params[0];
     }
 
     /**
@@ -259,7 +259,7 @@ class Validator
     {
         $length = $this->stringLength($value);
 
-        return $length >= $params[0] && $length <= $params[1];
+        return ($length !== false) && $length >= $params[0] && $length <= $params[1];
     }
 
     /**
@@ -273,7 +273,9 @@ class Validator
      */
     protected function validateLengthMin($field, $value, $params)
     {
-        return $this->stringLength($value) >= $params[0];
+        $length = $this->stringLength($value);
+
+        return ($length !== false) && $length >= $params[0];
     }
 
     /**
@@ -287,18 +289,22 @@ class Validator
      */
     protected function validateLengthMax($field, $value, $params)
     {
-        return $this->stringLength($value) <= $params[0];
+        $length = $this->stringLength($value);
+
+        return ($length !== false) && $length <= $params[0];
     }
 
     /**
      * Get the length of a string
      *
      * @param  string $value
-     * @return int
+     * @return int|false
      */
     protected function stringLength($value)
     {
-        if (function_exists('mb_strlen')) {
+        if (!is_string($value)) {
+            return false;
+        } elseif (function_exists('mb_strlen')) {
             return mb_strlen($value);
         }
 

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -322,7 +322,9 @@ class Validator
      */
     protected function validateMin($field, $value, $params)
     {
-        if (function_exists('bccomp')) {
+        if (!is_numeric($value)) {
+            return false;
+        } elseif (function_exists('bccomp')) {
             return !(bccomp($params[0], $value, 14) == 1);
         } else {
             return $params[0] <= $value;
@@ -340,7 +342,9 @@ class Validator
      */
     protected function validateMax($field, $value, $params)
     {
-        if (function_exists('bccomp')) {
+        if (!is_numeric($value)) {
+            return false;
+        } elseif (function_exists('bccomp')) {
             return !(bccomp($value, $params[0], 14) == 1);
         } else {
             return $params[0] >= $value;

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -222,6 +222,14 @@ class ValidateTest extends BaseTestCase
         $v = new Validator(array('num' => 5));
         $v->rule('min', 'num', 6);
         $this->assertFalse($v->validate());
+
+        $v = new Validator(array('test' => array()));
+        $v->rule('min', 'test', 1);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('test' => new stdClass));
+        $v->rule('min', 'test', 1);
+        $this->assertFalse($v->validate());
     }
 
     public function testMinInvalidFloat()
@@ -261,6 +269,14 @@ class ValidateTest extends BaseTestCase
     {
         $v = new Validator(array('num' => 5));
         $v->rule('max', 'num', 4);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('test' => array()));
+        $v->rule('min', 'test', 1);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('test' => new stdClass));
+        $v->rule('min', 'test', 1);
         $this->assertFalse($v->validate());
     }
 

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -131,6 +131,14 @@ class ValidateTest extends BaseTestCase
         $v = new Validator(array('str' => 'sad'));
         $v->rule('length', 'str', 6);
         $this->assertFalse($v->validate());
+
+        $v = new Validator(array('test' => array()));
+        $v->rule('length', 'test', 1);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('test' => new stdClass));
+        $v->rule('length', 'test', 1);
+        $this->assertFalse($v->validate());
     }
 
     public function testLengthBetweenValid()
@@ -144,6 +152,14 @@ class ValidateTest extends BaseTestCase
     {
         $v = new Validator(array('str' => 'sad'));
         $v->rule('lengthBetween', 'str', 4, 10);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('test' => array()));
+        $v->rule('lengthBetween', 'test', 50, 60);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('test' => new stdClass));
+        $v->rule('lengthBetween', 'test', 99, 100);
         $this->assertFalse($v->validate());
     }
 

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -1025,6 +1025,34 @@ class ValidateTest extends BaseTestCase
       $this->assertFalse($v->validate());
     }
 
+    /**
+     * @dataProvider dataProviderFor_testError
+     */
+    public function testError($expected, $input, $test, $message)
+    {
+        $v = new Validator(array('test' => $input));
+        $v->error('test', $message, $test);
+
+        $this->assertEquals(array('test' => array($expected)), $v->errors());
+    }
+
+    public function dataProviderFor_testError()
+    {
+        return array(
+            array(
+                'expected' => 'Test must be at least 140 long',
+                'input'    => 'tweeet',
+                'test'     => array(140),
+                'message'  => '{field} must be at least %d long',
+            ),
+            array(
+                'expected' => 'Test must be between 1 and 140 characters',
+                'input'    => array(1, 2, 3),
+                'test'     => array(1, 140),
+                'message'  => 'Test must be between %d and %d characters',
+            ),
+        );
+    }
 }
 
 function sampleFunctionCallback($field, $value, array $params) {


### PR DESCRIPTION
I'm trying to valitron but, valitron cause an error.

```php
// Request URI: /test.php?mode[$a]=1

var_export($_GET);
// array ( 'id' => array ( '$a' => '1', ), )

$v = new Valitron\Validator($_GET);
$v->rule('min', 'id', 1);
$v->validate();
// raise ErrorException (E_WARNING)
// bccomp() expects parameter 2 to be string, array given

$v = new Valitron\Validator($_GET);
$v->rule('length', 'id', 1);
$v->validate();
// raise ErrorException (E_WARNING)
// mb_strlen() expects parameter 1 to be string, array given
```

## testError

I made this test for to study valitron. If you do not need this test, I will remove it.
