### PR TITLE
add forceValidateEmptyValues method to validate empty strings

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -65,6 +65,11 @@ class Validator
     protected $validUrlPrefixes = array('http://', 'https://', 'ftp://');
 
     /**
+     * @var boolean
+     */
+    protected $forceValidateEmptyValues = false;
+
+    /**
      * Setup validation
      *
      * @param  array                     $data
@@ -857,6 +862,19 @@ class Validator
     }
 
     /**
+     * Force Validate Empty Values
+     *
+     * @param boolean $flag
+     */
+    public function forceValidateEmptyValues($flag)
+    {
+        if (!is_bool($flag)) {
+            throw new LogicException('invalid parametor has specified');
+        }
+        $this->forceValidateEmptyValues = $flag;
+    }
+
+    /**
      * Run validations and return boolean result
      *
      * @return boolean
@@ -868,7 +886,7 @@ class Validator
                  list($values, $multiple) = $this->getPart($this->_fields, explode('.', $field));
 
                 // Don't validate if the field is not required and the value is empty
-                if ($v['rule'] !== 'required' && !$this->hasRule('required', $field) && (! isset($values) || $values === '' || ($multiple && count($values) == 0))) {
+                if ($this->forceValidateEmptyValues === false && $v['rule'] !== 'required' && !$this->hasRule('required', $field) && (! isset($values) || $values === '' || ($multiple && count($values) == 0))) {
                     continue;
                 }
 

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -869,7 +869,7 @@ class Validator
     public function forceValidateEmptyValues($flag)
     {
         if (!is_bool($flag)) {
-            throw new LogicException('invalid parametor has specified');
+            throw new \InvalidArgumentException('First parameter must be a boolean true/false');
         }
         $this->forceValidateEmptyValues = $flag;
     }

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -585,11 +585,19 @@ class ValidateTest extends BaseTestCase
     /**
      * @group issue-13
      */
-    public function testDateValidWhenEmptyButNotRequired()
+    public function testdatevalidwhenemptybutnotrequired()
+    {
+        $v = new validator(array('date' => ''));
+        $v->rule('date', 'date');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testDateValidWhenEmptyButNotRequiredAndForceValidateEmptyValuesIsEnabled()
     {
         $v = new Validator(array('date' => ''));
         $v->rule('date', 'date');
-        $this->assertTrue($v->validate());
+        $v->forceValidateEmptyValues(true);
+        $this->assertFalse($v->validate());
     }
 
     public function testDateFormatValid()

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -585,9 +585,9 @@ class ValidateTest extends BaseTestCase
     /**
      * @group issue-13
      */
-    public function testdatevalidwhenemptybutnotrequired()
+    public function testDateValidWhenEmptyButNotRequired()
     {
-        $v = new validator(array('date' => ''));
+        $v = new Validator(array('date' => ''));
         $v->rule('date', 'date');
         $this->assertTrue($v->validate());
     }


### PR DESCRIPTION
i don't need to allow empty string values to use this library in my apis;
but i know why validate only not empty string values from [this issue](https://github.com/vlucas/valitron/issues/136)

So I made a special option for validate empty string values.

How about this?