### PR TITLE
Added "optional" rule validation

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -731,6 +731,12 @@ class Validator
         return $isInstanceOf;
     }
 
+    //Validate optional field
+    protected function validateOptional($field, $value, $params) {
+        //Always return true
+        return true;
+    }
+
     /**
      *  Get array of fields and data
      *
@@ -868,7 +874,9 @@ class Validator
                  list($values, $multiple) = $this->getPart($this->_fields, explode('.', $field));
 
                 // Don't validate if the field is not required and the value is empty
-                if ($v['rule'] !== 'required' && !$this->hasRule('required', $field) && (! isset($values) || $values === '' || ($multiple && count($values) == 0))) {
+                if ($this->hasRule('optional', $field) && isset($values)) {
+                    //Continue with execution below if statement
+                } elseif ($v['rule'] !== 'required' && !$this->hasRule('required', $field) && (! isset($values) || $values === '' || ($multiple && count($values) == 0))) {
                     continue;
                 }
 

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -1085,6 +1085,27 @@ class ValidateTest extends BaseTestCase
             ),
         );
     }
+
+    public function testOptionalProvidedValid()
+    {
+        $v = new Validator(array('address' =>  'user@example.com'));   
+        $v->rule('optional', 'address')->rule('email', 'address');        
+        $this->assertTrue($v->validate());
+    }
+
+    public function testOptionalProvidedInvalid()
+    {
+        $v = new Validator(array('address' =>  'userexample.com'));   
+        $v->rule('optional', 'address')->rule('email', 'address');        
+        $this->assertFalse($v->validate());
+    }
+
+    public function testOptionalNotProvided()
+    {
+        $v = new Validator(array());   
+        $v->rule('optional', 'address')->rule('email', 'address');        
+        $this->assertTrue($v->validate());
+    }    
 }
 
 function sampleFunctionCallback($field, $value, array $params) {


### PR DESCRIPTION
With 'optional' rule validation, values does not need to be included in data array.
However, if they are, they must pass validation. So, any validation, even if they are empty or ''.

Before this patch, if you pass data with empty ( '' ) value, then it is ignored if "required" was not added.
With this version, this is now fixed.

Test case available here: http://pastebin.com/N2eQjJys