### PR TITLE
Pass fields to callbacks defined in addRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ case of an error. The callback provided should return boolean true or
 false.
 
 ```php
-Valitron\Validator::addRule('alwaysFail', function($field, $value, array $params) {
+Valitron\Validator::addRule('alwaysFail', function($field, $value, array $params, array $fields) {
     return false;
 }, 'Everything you do is wrong. You fail.');
 ```

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -885,7 +885,7 @@ class Validator
 
                 $result = true;
                 foreach ($values as $value) {
-                    $result = $result && call_user_func($callback, $field, $value, $v['params']);
+                    $result = $result && call_user_func($callback, $field, $value, $v['params'], $this->_fields);
                 }
 
                 if (!$result) {


### PR DESCRIPTION
This would fix #87, by giving custom rule callbacks access to data from other fields, through an optional fourth parameter.

## Example Use Case

I'm developing an application that requires users to submit an API key and Mailbox ID from a particular help desk application.

In addition to validating length/alphaNum, etc., I have written a custom rule that verifies the API key by making a test request.

With this pull request in place, I could write a _second_ custom rule that uses the API key from the first field to test the existence of the Mailbox ID. For example:

```
$callback = function( $field, $value, array $params, array $fields ) {
    // Grab the associated API key field
    $apiKey = $fields[ $params[0] ];

    // Grab a new API Request object
    $api = new \ThirdPartyApi\Request( $apiKey );

    // If the API's getMailbox call returns false, so should we
    if ( $api->getMailbox( $value ) == false )
        return false;
    else
        return true;
};

\Valitron\Validator::addRule( 'validMailboxId', $callback, "couldn't be found." );
```