### PR TITLE
Added ifNotSet rule feature

### DIFF
--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -1088,24 +1088,45 @@ class ValidateTest extends BaseTestCase
 
     public function testOptionalProvidedValid()
     {
-        $v = new Validator(array('address' =>  'user@example.com'));   
-        $v->rule('optional', 'address')->rule('email', 'address');        
+        $v = new Validator(array('address' =>  'user@example.com'));
+        $v->rule('optional', 'address')->rule('email', 'address');
         $this->assertTrue($v->validate());
     }
 
     public function testOptionalProvidedInvalid()
     {
-        $v = new Validator(array('address' =>  'userexample.com'));   
-        $v->rule('optional', 'address')->rule('email', 'address');        
+        $v = new Validator(array('address' =>  'userexample.com'));
+        $v->rule('optional', 'address')->rule('email', 'address');
         $this->assertFalse($v->validate());
     }
 
     public function testOptionalNotProvided()
     {
-        $v = new Validator(array());   
-        $v->rule('optional', 'address')->rule('email', 'address');        
+        $v = new Validator(array());
+        $v->rule('optional', 'address')->rule('email', 'address');
         $this->assertTrue($v->validate());
-    }    
+    }
+
+    public function testIfNotSetIsSet()
+    {
+        $v = new Validator(array('name' => 'Daniel'));
+        $v->rule('ifNotSet', 'name', array('rule' => 'required', 'field' => 'lastname'));
+        $this->assertTrue($v->validate());
+    }
+
+    public function testIfNotSetIsNotSetProvided()
+    {
+        $v = new Validator(array('lastname' => 'Doe'));
+        $v->rule('ifNotSet', 'name', array('rule' => 'required', 'field' => 'lastname'));
+        $this->assertTrue($v->validate());
+    }
+
+    public function testIfNotSetIsNotSetNotProvided()
+    {
+        $v = new Validator(array('firstname' => 'Daniel'));
+        $v->rule('ifNotSet', 'name', array('rule' => 'required', 'field' => 'lastname'));
+        $this->assertFalse($v->validate());
+    }
 }
 
 function sampleFunctionCallback($field, $value, array $params) {


### PR DESCRIPTION
Hi, I had problem to add some conditional rules. Optional didn't entirely do the trick for me because in the case where I want one of two fields to be valid and if non of the fields where set, then nothing happened. So I thought that I could add a rule ifNotSet that triggers another rule for another field if this one don't exist.

        $v = new Validator(array('place_id' => 12));
        $v->rule('ifNotSet', 'place_id', array('rule' => 'required', 'field' => 'lastname'));
        $v->validate(); //test pass


        $v = new Validator(array('place_name' => 'Grenoble'));
        $v->rule('ifNotSet', 'place_id', array('rule' => 'alpha', 'field' => 'place_name'));
        $v->validate();  //test also pass

        $v = new Validator(array());
        $v->rule('ifNotSet', 'place_id', array('rule' => 'required', 'field' => 'place_name'));
        $v->validate(); //test fail


It's my first contribution on a gitHub open source project so I'm open to any suggestion :)