### PR TITLE
Added dependent validations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,29 @@ $v->validate();
 
 This introduces a new set of tags to your error language file which looks like `{field}`, if you are using a rule like `equals` you can access the second value in the language file by incrementing the field with a value like `{field1}`.
 
+## Conditional rules
+
+You can add a set of rules that depend on a condition. If the previous condition fails validation, it doesn't cause the validate() method to return false, but means the dependent set of rules won't be checked. For example:
+
+```php
+    $this->condition('min', 'age', 18, function($d) {
+            $d->rule('required', 'credit_card')
+              ->rule('creditCard, 'credit_card');
+        });       
+```
+
+The age of use doesn't have to be more than 18, but if it is, we require them to supply a credit card, and validate. You can add more dependent rules inside a dependent rule set:
+```php
+    $this->condition(function($c) {            
+              $c->condition('min', 'age', 18, function($c2) {
+                //... And so on
+              });
+        });       
+```
+
+You can even set labels and messages inside the dependent set!  
+
+
 ## Re-use of validation rules
 
 You can re-use your validation rules to quickly validate different data with the same rules by using the withData method:

--- a/src/Valitron/ValidationSet.php
+++ b/src/Valitron/ValidationSet.php
@@ -1,0 +1,195 @@
+<?php
+namespace Valitron;
+
+use Valitron\Validator;
+
+class ValidationSet implements ValidationSetInterface
+{
+    /**
+     * @var Validator
+     */
+    protected $parentValidator;
+    /**
+     * @var array
+     */
+    protected $validations = array();
+    /**
+     * @var array
+     */
+    protected $labels  = array();
+
+    public function __construct(Validator $validator)
+    {
+        $this->parentValidator = $validator;
+    }
+
+    /**
+     * @param string $rule
+     * @param string|array $fields
+	 * @param mixed ... $arguments
+     * @return $this
+     */
+    public function rule($rule, $fields)
+    {
+		// Get any other arguments passed to function
+        $params = array_slice(func_get_args(), 2);
+
+		if (is_callable($rule)
+			&& !(is_string($rule) && $this->parentValidator->hasValidator($rule)))
+		{
+			$name = $this->parentValidator->getUniqueRuleName($fields);
+			$msg = isset($params[0]) ? $params[0] : null;
+			$this->parentValidator->addInstanceRule($name, $rule, $msg);
+			$rule = $name;
+		}
+
+		$rules = $this->parentValidator->getRules();
+		if (!isset($rules[$rule])) {
+            $ruleMethod = 'validate' . ucfirst($rule);
+            if (!method_exists($this->parentValidator, $ruleMethod)) {
+                throw new \InvalidArgumentException("Rule '" . $rule . "' has not been registered with {".get_class($this->parentValidator)."::addRule().");
+            }
+        }
+
+        // Ensure rule has an accompanying message
+		$msgs = $this->parentValidator->getRuleMessages();
+		$parentValidatorClass = get_class($this->parentValidator);
+		$message = isset($msgs[$rule]) ? $msgs[$rule] : $parentValidatorClass::ERROR_DEFAULT;
+
+        $newRule = array(
+            'rule' => $rule,
+            'fields' => (array)$fields,
+            'params' => (array)$params,
+            'message' => '{field} ' . $message
+        );
+
+        $this->validations[] = $newRule;
+
+        return $this;
+    }
+
+	/**
+	 * @param $rule
+	 * @param $_
+	 * @return $this
+	 * @internal param callable $callback
+	 */
+    public function condition($rule, $_)
+    {
+		$params = func_get_args();
+		$callback = array_pop($params);
+
+        if (!is_callable($callback)) {
+            throw new \InvalidArgumentException('Argument must be a valid callback. Given argument was not callable.');
+        }
+
+		$dependent = new self($this->parentValidator);
+
+        $callback($dependent);
+
+		call_user_func_array(array($this, 'rule'), $params);
+        $this->validations[count($this->validations) - 1]['dependent'] = $dependent;
+
+        return $this;
+    }
+
+    /**
+     * @param string $msg
+     * @return $this
+     */
+    public function message($msg)
+    {
+        $lastValidation = count($this->validations) - 1;
+        $this->validations[$lastValidation]['message'] = $msg;
+
+        return $this;
+    }
+
+    /**
+     * @param  string $value
+     * @internal param array $labels
+     * @return $this
+     */
+    public function label($value)
+    {
+        $lastValidation = count($this->validations) - 1;
+
+        $lastRules = $this->validations[$lastValidation]['fields'];
+
+        $this->labels(array($lastRules[0] => $value));
+
+        return $this;
+    }
+
+    /**
+     * @param  array $labels
+     * @return string
+     */
+    public function labels($labels)
+    {
+        $this->labels = array_merge($this->labels, $labels);
+
+        return $this;
+    }
+
+    /**
+     * Convenience method to add multiple validation rules with an array
+     *
+     * @param array $rules
+     */
+    public function rules($rules)
+    {
+        foreach ($rules as $ruleType => $params) {
+            if (is_array($params)) {
+                foreach ($params as $innerParams) {
+                    array_unshift($innerParams, $ruleType);
+                    call_user_func_array(array($this, 'rule'), $innerParams);
+                }
+            } else {
+                $this->rule($ruleType, $params);
+            }
+        }
+    }
+
+    protected function ruleExists($rule) {
+        return forward_static_call(array(get_class($this->parentValidator), 'ruleExists'), $rule);
+    }
+
+    protected function getRuleMessage($rule) {
+        return forward_static_call(array(get_class($this->parentValidator), 'getRuleMessage'), $rule);
+    }
+
+    /**
+     * @return array
+     */
+    public function getValidations()
+    {
+        return $this->validations;
+    }
+
+    /**
+     * @param $name
+     * @param $field
+     * @return boolean
+     */
+    public function hasRule($name, $field)
+    {
+        foreach ($this->validations as $validation) {
+            if ($validation['rule'] == $name) {
+                if (in_array($field, $validation['fields'])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLabels()
+    {
+        return $this->labels;
+    }
+}

--- a/src/Valitron/ValidationSetInterface.php
+++ b/src/Valitron/ValidationSetInterface.php
@@ -1,0 +1,72 @@
+<?php
+namespace Valitron;
+
+
+interface ValidationSetInterface
+{
+    /**
+     * Convenience method to add a single validation rule
+     *
+     * @param  string $rule
+     * @param  array|string $fields fields
+	 * @param  mixed ... $arguments
+     * @return $this
+     * @throws \InvalidArgumentException
+     */
+    public function rule($rule, $fields);
+
+    /**
+     * @param  string $value
+     * @internal param array $labels
+     * @return $this
+     */
+    public function label($value);
+
+    /**
+     * @param  array  $labels
+     * @return string
+     */
+    public function labels($labels);
+
+    /**
+     * Specify validation message to use for error for the last validation rule
+     *
+     * @param  string $msg
+     * @return $this
+     */
+    public function message($msg);
+
+    /**
+     * Convenience method to add multiple validation rules with an array
+     *
+     * @param array $rules
+     */
+    public function rules($rules);
+
+	/**
+	 * Chain another ValidationSet to last set rule
+	 *
+	 * @param $rule
+	 * @param $_
+	 * @return $this
+	 */
+    public function condition($rule, $_);
+
+    /**
+     * @return array
+     */
+    public function getValidations();
+
+    /**
+     * @param $name
+     * @param $field
+     * @return boolean
+     */
+    public function hasRule($name, $field);
+
+    /**
+     * @return array
+     */
+    public function getLabels();
+
+}

--- a/tests/Valitron/ConditionTest.php
+++ b/tests/Valitron/ConditionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Valitron\ValidationSetInterface;
+use Valitron\Validator;
+
+class ConditionTest extends BaseTestCase
+{
+    public function testDependentSuccessfulValidation()
+    {
+        $v = new Validator(array('name' => 'John Doe', 'age' => '17'));
+        $v->condition('min', 'age', 17, function(ValidationSetInterface $c) {
+                $c->rule('required', 'name');
+            })
+			->condition('max', 'age', 15, function(ValidationSetInterface $c) {
+                $c->rule('required', 'foo');
+            });
+        $this->assertTrue($v->validate());
+    }
+
+    public function testDependentRequired()
+    {
+        $v = new Validator(array('pets' => 'gerbil'));
+        $v->rule('required', 'pets');
+        $v->condition('required', 'name', function(ValidationSetInterface $c) {
+                $c->rule('required', 'age');
+            });
+        $this->assertTrue($v->validate());
+    }
+
+    public function testDependentSuccessfulValidationTwoLevels()
+    {
+        $v = new Validator(array('name' => 'John Doe', 'age' => '17', 'pets' => 'dog'));
+        $v->condition('min', 'age', 17, function(ValidationSetInterface $c) {
+                    $c->condition('required', 'name', function(ValidationSetInterface $c) {
+                        $c->rule('in', 'pets', array('dog', 'cat', 'goldfish'));
+                    });
+            })
+            ->condition('max', 'age', 15, function(ValidationSetInterface $c) {
+                $c->rule('required', 'foo');
+            });
+        $this->assertTrue($v->validate());
+    }
+
+    public function testDependentFailedValidation()
+    {
+        $v = new Validator(array('name' => 'John Doe', 'age' => '17'));
+        $v->condition('min', 'age', 17, function(ValidationSetInterface $c) {
+                $c->rule('required', 'name')
+                    ->rule('required', 'foo');
+            });
+        $this->assertFalse($v->validate());
+    }
+
+    public function testDependentFailedValidationTwoLevels()
+    {
+        $v = new Validator(array('name' => 'John Doe', 'age' => '17', 'pets' => 'gerbil'));
+        $v->condition('min', 'age', 17, function(ValidationSetInterface $c) {
+                $c->condition('required', 'name', function(ValidationSetInterface $c) {
+                        $c->rule('in', 'pets', array('dog', 'cat', 'goldfish'));
+                    });
+            })
+            ->condition('max', 'age', 15, function(ValidationSetInterface $c) {
+                $c->rule('required', 'foo');
+            });
+        $this->assertFalse($v->validate());
+    }
+
+    public function testDependentSetLabel()
+    {
+        $v = new Validator(array('age' => '17'));
+        $v->condition('min', 'age', 17, function(ValidationSetInterface $c) {
+                $c->rule('required', 'name')->label('Your name')
+					->rule('required', 'bar')->message('{field} Ouch.')
+					->rule('required', 'buzz');
+            });
+
+        $v->labels(array('bar' => 'A man walks into a bar.'));
+
+        $v->validate();
+        $expectedErrors = array(
+            'name' => array('Your name is required'),
+            'bar' => array('A man walks into a bar. Ouch.'),
+            'buzz' => array('Buzz is required'),
+        );
+        $this->assertEquals($expectedErrors, $v->errors());
+    }
+}


### PR DESCRIPTION
Ability to attach several rules to another rule only be validated if the parent rule passes.

Example: 
You want to validate that a user has included their credit card number if their age exceeds 18, so you could do something like this:

```
$this->rule('min', 'age', 18)
    ->chain('required', 'credit_card')
    ->chain('creditCard', 'credit_card')
```

This pull request only supports adding a single leveling of chaining with the helper functions. But the validateChain function could recurse infinitely if deeper chains were added.
