### PR TITLE
Add anonymous and instance rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,29 @@ Valitron\Validator::addRule('alwaysFail', function($field, $value, array $params
 }, 'Everything you do is wrong. You fail.');
 ```
 
+You can also use one-off rules that are only valid for the specified
+fields. 
+
+```php
+$v = new Valitron\Validator(array("foo" => "bar"));
+$v->rule(function($field, $value, $params, $fields) {
+    return true;
+}, "foo")->message("{field} failed...");
+```
+
+This is useful because such rules can have access to variables
+defined in the scope where the `Validator` lives. The Closure's
+signature is identical to `Validator::addRule` callback's
+signature. 
+
+If you wish to add your own rules that are not static (i.e.,
+your rule is not static and available to call `Validator` 
+instances), you need to use `Validator::addInstanceRule`. 
+This rule will take the same parameters as 
+`Validator::addRule` but it has to be called on a `Validator`
+instance.
+
+
 ## Alternate syntax for adding rules
 
 As the number of rules grows, you may prefer the alternate syntax

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -1037,10 +1037,10 @@ class Validator
      */
     public static function addRule($name, $callback, $message = null)
     {
-		if ($message === null)
-		{
-			$message = static::ERROR_DEFAULT;
-		}
+        if ($message === null)
+        {
+            $message = static::ERROR_DEFAULT;
+        }
 
         static::assertRuleCallback($callback);
 
@@ -1048,23 +1048,23 @@ class Validator
         static::$_ruleMessages[$name] = $message;
     }
 
-	public function getUniqueRuleName($fields)
-	{
-		if (is_array($fields))
-		{
-			$fields = implode("_", $fields);
-		}
+    public function getUniqueRuleName($fields)
+    {
+        if (is_array($fields))
+        {
+            $fields = implode("_", $fields);
+        }
 
-		$orgName = "{$fields}_rule";
-		$name = $orgName;
-    $rules = $this->getRules();
-		while (isset($rules[$name]))
-		{
-			$name = $orgName . "_" . rand(0, 10000);
-		}
+        $orgName = "{$fields}_rule";
+        $name = $orgName;
+        $rules = $this->getRules();
+        while (isset($rules[$name]))
+        {
+            $name = $orgName . "_" . rand(0, 10000);
+        }
 
-		return $name;
-	}
+        return $name;
+    }
 
     /**
      * Convenience method to add a single validation rule
@@ -1079,19 +1079,19 @@ class Validator
         // Get any other arguments passed to function
         $params = array_slice(func_get_args(), 2);
 
-		// Note: we cannot use is_callable here since max, int, and many
-		// other string can also be callables but aren't really rule callbacks.
-		//
-		// If a closure is used, we can be sure that the user actually
-		// wants $rule to be a custom rule check.
-		if (is_object($rule) && ($rule instanceof \Closure))
-		{
-			$name = $this->getUniqueRuleName($fields);
-			$msg = isset($params[0]) ? $params[0] : null;
-			$this->addInstanceRule($name, $rule, $msg);
-			$rule = $name;
-		}
-			
+        // Note: we cannot use is_callable here since max, int, and many
+        // other string can also be callables but aren't really rule callbacks.
+        //
+        // If a closure is used, we can be sure that the user actually
+        // wants $rule to be a custom rule check.
+        if (is_object($rule) && ($rule instanceof \Closure))
+        {
+            $name = $this->getUniqueRuleName($fields);
+            $msg = isset($params[0]) ? $params[0] : null;
+            $this->addInstanceRule($name, $rule, $msg);
+            $rule = $name;
+        }
+
         $errors = $this->getRules();
         if (!isset($errors[$rule])) {
             $ruleMethod = 'validate' . ucfirst($rule);

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -1067,6 +1067,20 @@ class Validator
     }
 
     /**
+     * Returns true if either a valdiator with the given name has been
+     * registered or there is a default validator by that name.
+     *
+     * @param string    $name
+     * @return bool
+     */
+    public function hasValidator($name)
+    {
+        $rules = $this->getRules();
+        return method_exists($this, "validate" . ucfirst($name))
+            || isset($rules[$name]);
+    }
+
+    /**
      * Convenience method to add a single validation rule
      *
      * @param  string|callback           $rule
@@ -1079,12 +1093,8 @@ class Validator
         // Get any other arguments passed to function
         $params = array_slice(func_get_args(), 2);
 
-        // Note: we cannot use is_callable here since max, int, and many
-        // other string can also be callables but aren't really rule callbacks.
-        //
-        // If a closure is used, we can be sure that the user actually
-        // wants $rule to be a custom rule check.
-        if (is_object($rule) && ($rule instanceof \Closure))
+        if (is_callable($rule)
+            && !(is_string($rule) && $this->hasValidator($rule)))
         {
             $name = $this->getUniqueRuleName($fields);
             $msg = isset($params[0]) ? $params[0] : null;

--- a/tests/Valitron/ValidateAddInstanceRuleTest.php
+++ b/tests/Valitron/ValidateAddInstanceRuleTest.php
@@ -1,0 +1,56 @@
+<?php
+use Valitron\Validator;
+
+class ValidateAddInstanceRuleTest extends BaseTestCase
+{
+	protected function assertValid($v)
+	{
+		$msg = "\tErrors:\n";
+		$status = $v->validate();
+		foreach ($v->errors() as $label => $messages)
+		{
+			foreach ($messages as $theMessage)
+			{
+				$msg .= "\n\t{$label}: {$theMessage}";
+			}
+		}
+
+		$this->assertTrue($v->validate(), $msg);
+	}
+
+	public function testAddInstanceRule()
+	{
+		$v = new Validator(array(
+			"foo" => "bar",
+			"fuzz" => "bazz",
+		));
+
+		$v->addInstanceRule("fooRule", function($field, $value)
+		{
+			return $field !== "foo" || $value !== "barz";
+		});
+
+		Validator::addRule("fuzzerRule", function($field, $value)
+		{
+			return $field !== "fuzz" || $value === "bazz";
+		});
+
+		$v->rule("required", array("foo", "fuzz"));
+		$v->rule("fuzzerRule", "fuzz");
+		$v->rule("fooRule", "foo");
+
+
+		$this->assertValid($v);
+	}
+
+	public function testAddInstanceRuleFail()
+	{
+		$v = new Validator(array("foo" => "bar"));
+		$v->addInstanceRule("fooRule", function($field)
+		{
+			return $field === "for";
+		});
+		$v->rule("fooRule", "foo");
+		$this->assertFalse($v->validate());
+	}
+}

--- a/tests/Valitron/ValidateAddInstanceRuleTest.php
+++ b/tests/Valitron/ValidateAddInstanceRuleTest.php
@@ -1,6 +1,11 @@
 <?php
 use Valitron\Validator;
 
+function callbackTestFunction($item, $value)
+{
+	return $value === "bar";
+}
+
 class ValidateAddInstanceRuleTest extends BaseTestCase
 {
     protected function assertValid($v)
@@ -86,6 +91,20 @@ class ValidateAddInstanceRuleTest extends BaseTestCase
         $this->assertCount(1, $errors["foo"]);
         $this->assertEquals("Foo test error message", $errors["foo"][0]);
     }
+
+	public function testAddRuleWithNamedCallbackOk()
+	{
+		$v = new Validator(array("bar" => "foo"));
+		$v->rule("callbackTestFunction", "bar");
+		$this->assertFalse($v->validate());
+	}
+
+	public function testAddRuleWithNamedCallbackErr()
+	{
+		$v = new Validator(array("foo" => "bar"));
+		$v->rule("callbackTestFunction", "foo");
+		$this->assertTrue($v->validate());
+	}
 
     public function testUniqueRuleName()
     {

--- a/tests/Valitron/ValidateAddInstanceRuleTest.php
+++ b/tests/Valitron/ValidateAddInstanceRuleTest.php
@@ -3,99 +3,99 @@ use Valitron\Validator;
 
 class ValidateAddInstanceRuleTest extends BaseTestCase
 {
-	protected function assertValid($v)
-	{
-		$msg = "\tErrors:\n";
-		$status = $v->validate();
-		foreach ($v->errors() as $label => $messages)
-		{
-			foreach ($messages as $theMessage)
-			{
-				$msg .= "\n\t{$label}: {$theMessage}";
-			}
-		}
+    protected function assertValid($v)
+    {
+        $msg = "\tErrors:\n";
+        $status = $v->validate();
+        foreach ($v->errors() as $label => $messages)
+        {
+            foreach ($messages as $theMessage)
+            {
+                $msg .= "\n\t{$label}: {$theMessage}";
+            }
+        }
 
-		$this->assertTrue($v->validate(), $msg);
-	}
+        $this->assertTrue($v->validate(), $msg);
+    }
 
-	public function testAddInstanceRule()
-	{
-		$v = new Validator(array(
-			"foo" => "bar",
-			"fuzz" => "bazz",
-		));
+    public function testAddInstanceRule()
+    {
+        $v = new Validator(array(
+            "foo" => "bar",
+            "fuzz" => "bazz",
+        ));
 
-		$v->addInstanceRule("fooRule", function($field, $value)
-		{
-			return $field !== "foo" || $value !== "barz";
-		});
+        $v->addInstanceRule("fooRule", function($field, $value)
+        {
+            return $field !== "foo" || $value !== "barz";
+        });
 
-		Validator::addRule("fuzzerRule", function($field, $value)
-		{
-			return $field !== "fuzz" || $value === "bazz";
-		});
+        Validator::addRule("fuzzerRule", function($field, $value)
+        {
+            return $field !== "fuzz" || $value === "bazz";
+        });
 
-		$v->rule("required", array("foo", "fuzz"));
-		$v->rule("fuzzerRule", "fuzz");
-		$v->rule("fooRule", "foo");
+        $v->rule("required", array("foo", "fuzz"));
+        $v->rule("fuzzerRule", "fuzz");
+        $v->rule("fooRule", "foo");
 
-		$this->assertValid($v);
-	}
+        $this->assertValid($v);
+    }
 
-	public function testAddInstanceRuleFail()
-	{
-		$v = new Validator(array("foo" => "bar"));
-		$v->addInstanceRule("fooRule", function($field)
-		{
-			return $field === "for";
-		});
-		$v->rule("fooRule", "foo");
-		$this->assertFalse($v->validate());
-	}
+    public function testAddInstanceRuleFail()
+    {
+        $v = new Validator(array("foo" => "bar"));
+        $v->addInstanceRule("fooRule", function($field)
+        {
+            return $field === "for";
+        });
+        $v->rule("fooRule", "foo");
+        $this->assertFalse($v->validate());
+    }
 
-	public function testAddAddRuleWithCallback()
-	{
-		$v = new Validator(array("foo" => "bar"));
-		$v->rule(function($field, $value) {
-			return $field === "foo" && $value === "bar";
-		}, "foo");
+    public function testAddAddRuleWithCallback()
+    {
+        $v = new Validator(array("foo" => "bar"));
+        $v->rule(function($field, $value) {
+            return $field === "foo" && $value === "bar";
+        }, "foo");
 
-		$this->assertValid($v);
-	}
+        $this->assertValid($v);
+    }
 
-	public function testAddAddRuleWithCallbackFail()
-	{
-		$v = new Validator(array("foo" => "baz"));
-		$v->rule(function($field, $value) {
-			return $field === "foo" && $value === "bar";
-		}, "foo");
+    public function testAddAddRuleWithCallbackFail()
+    {
+        $v = new Validator(array("foo" => "baz"));
+        $v->rule(function($field, $value) {
+            return $field === "foo" && $value === "bar";
+        }, "foo");
 
-		$this->assertFalse($v->validate());
-	}
+        $this->assertFalse($v->validate());
+    }
 
-	public function testAddAddRuleWithCallbackFailMessage()
-	{
-		$v = new Validator(array("foo" => "baz"));
-		$v->rule(function($field, $value) {
-			return $field === "foo" && $value === "bar";
-		}, "foo", "test error message");
+    public function testAddAddRuleWithCallbackFailMessage()
+    {
+        $v = new Validator(array("foo" => "baz"));
+        $v->rule(function($field, $value) {
+            return $field === "foo" && $value === "bar";
+        }, "foo", "test error message");
 
-		$this->assertFalse($v->validate());
+        $this->assertFalse($v->validate());
     $errors = $v->errors();
-		$this->assertArrayHasKey("foo", $errors);
-		$this->assertCount(1, $errors["foo"]);
-		$this->assertEquals("Foo test error message", $errors["foo"][0]);
-	}
+        $this->assertArrayHasKey("foo", $errors);
+        $this->assertCount(1, $errors["foo"]);
+        $this->assertEquals("Foo test error message", $errors["foo"][0]);
+    }
 
-	public function testUniqueRuleName()
-	{
-		$v = new Validator(array());
-		$args = array("foo", "bar");
-		$this->assertEquals("foo_bar_rule", $v->getUniqueRuleName($args));
-		$this->assertEquals("foo_rule", $v->getUniqueRuleName("foo"));
+    public function testUniqueRuleName()
+    {
+        $v = new Validator(array());
+        $args = array("foo", "bar");
+        $this->assertEquals("foo_bar_rule", $v->getUniqueRuleName($args));
+        $this->assertEquals("foo_rule", $v->getUniqueRuleName("foo"));
 
-		$v->addInstanceRule("foo_rule", function() {});
-		$u = $v->getUniqueRuleName("foo");
-		$this->assertRegExp("/^foo_rule_[0-9]{1,5}$/", $u);
-	}
+        $v->addInstanceRule("foo_rule", function() {});
+        $u = $v->getUniqueRuleName("foo");
+        $this->assertRegExp("/^foo_rule_[0-9]{1,5}$/", $u);
+    }
 }

--- a/tests/Valitron/ValidateAddInstanceRuleTest.php
+++ b/tests/Valitron/ValidateAddInstanceRuleTest.php
@@ -39,7 +39,6 @@ class ValidateAddInstanceRuleTest extends BaseTestCase
 		$v->rule("fuzzerRule", "fuzz");
 		$v->rule("fooRule", "foo");
 
-
 		$this->assertValid($v);
 	}
 
@@ -52,5 +51,51 @@ class ValidateAddInstanceRuleTest extends BaseTestCase
 		});
 		$v->rule("fooRule", "foo");
 		$this->assertFalse($v->validate());
+	}
+
+	public function testAddAddRuleWithCallback()
+	{
+		$v = new Validator(array("foo" => "bar"));
+		$v->rule(function($field, $value) {
+			return $field === "foo" && $value === "bar";
+		}, "foo");
+
+		$this->assertValid($v);
+	}
+
+	public function testAddAddRuleWithCallbackFail()
+	{
+		$v = new Validator(array("foo" => "baz"));
+		$v->rule(function($field, $value) {
+			return $field === "foo" && $value === "bar";
+		}, "foo");
+
+		$this->assertFalse($v->validate());
+	}
+
+	public function testAddAddRuleWithCallbackFailMessage()
+	{
+		$v = new Validator(array("foo" => "baz"));
+		$v->rule(function($field, $value) {
+			return $field === "foo" && $value === "bar";
+		}, "foo", "test error message");
+
+		$this->assertFalse($v->validate());
+    $errors = $v->errors();
+		$this->assertArrayHasKey("foo", $errors);
+		$this->assertCount(1, $errors["foo"]);
+		$this->assertEquals("Foo test error message", $errors["foo"][0]);
+	}
+
+	public function testUniqueRuleName()
+	{
+		$v = new Validator(array());
+		$args = array("foo", "bar");
+		$this->assertEquals("foo_bar_rule", $v->getUniqueRuleName($args));
+		$this->assertEquals("foo_rule", $v->getUniqueRuleName("foo"));
+
+		$v->addInstanceRule("foo_rule", function() {});
+		$u = $v->getUniqueRuleName("foo");
+		$this->assertRegExp("/^foo_rule_[0-9]{1,5}$/", $u);
 	}
 }


### PR DESCRIPTION
# Add anonymous and instance rules #

This patch adds support for adding anonymous and instance rules. Those rules are not static and only valid for the current Validator instance. To add an instance rule, call addInstanceRule:

```php
$v->addInstanceRule("my_instance_rule", function() {
    return false;
}, "custom error message");
```

This rule will only be available to the current validator instance.

Furthermore, you can also add anonymous rules. Those rules don't have a name (actually they do but their name is not relevant and only an implementation detail), and can be used with Validator::rule directly:

```php
$v->rule(function() {
    return true;
}, ["field1, "field2"])->message("Hello world");
```

This rule will only be used for field1, and field2. This is extremely handy if you have need a rule for only one field (and you are not likely to be reusing that rule again). It is important to note that the given function needs to be a Closure, a callable is not enough [because of this](https://github.com/vlucas/valitron/compare/master...Matt3o12:addTmpRule?expand=1#diff-85536dd20345ab0156fbcf660928e6b5R1080).

For more details about anonymous and instance rules, as well as, the most important implementation details, please read the commits.