### PR TITLE
fix integer validation process

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -237,7 +237,7 @@ class Validator
      */
     protected function validateInteger($field, $value)
     {
-        return filter_var($value, \FILTER_VALIDATE_INT) !== false;
+        return preg_match('/^-?([0-9])+$/i', $value);
     }
 
     /**

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -110,11 +110,31 @@ class ValidateTest extends BaseTestCase
         $v = new Validator(array('num' => '41243'));
         $v->rule('integer', 'num');
         $this->assertTrue($v->validate());
+
+        $v = new Validator(array('num' => '-41243'));
+        $v->rule('integer', 'num');
+        $this->assertTrue($v->validate());
     }
 
     public function testIntegerInvalid()
     {
         $v = new Validator(array('num' => '42.341569'));
+        $v->rule('integer', 'num');
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('num' => ' 41243'));
+        $v->rule('integer', 'num');
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('num' => '+1231'));
+        $v->rule('integer', 'num');
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('num' => '--1231'));
+        $v->rule('integer', 'num');
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('num' => '0x3a'));
         $v->rule('integer', 'num');
         $this->assertFalse($v->validate());
     }

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -139,6 +139,14 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
+    public function testIntegerWithMaxValidation()
+    {
+        $v = new Validator(array('num' => '4212341569'));
+        $v->rule('integer', 'num');
+        $v->rule('max', 'num', 1000);
+        $this->assertFalse($v->validate());
+    }
+
     public function testLengthValid()
     {
         $v = new Validator(array('str' => 'happy'));

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -141,7 +141,7 @@ class ValidateTest extends BaseTestCase
 
     public function testIntegerWithMaxValidation()
     {
-        $v = new Validator(array('num' => '4212341569'));
+        $v = new Validator(array('num' => ' 4212341569'));
         $v->rule('integer', 'num');
         $v->rule('max', 'num', 1000);
         $this->assertFalse($v->validate());


### PR DESCRIPTION
Current code is using FILTER_VALIDATE_INT for validate integer values;

That options will ignore front "+" and any spaces. for example.
"+123123"  <= true
" 1231232" <= true

This is big problem for the max value validations.
```
$v = new Validator(array('num' => ' 42341521369'));
$v->rule('integer', 'num');
$v->rule('max', 'num', 1000);
$v->validate()); // True !!
```
