### PR TITLE
Fix issue where preg_match spews when passed an array

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -565,6 +565,9 @@ class Validator
      */
     protected function validateSlug($field, $value)
     {
+        if(is_array($value)) {
+            return false;
+        }
         return preg_match('/^([-a-z0-9_-])+$/i', $value);
     }
 

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -619,7 +619,7 @@ class ValidateTest extends BaseTestCase
     
     public function testNoErrorFailOnArray()
     {
-        $v = new Validator(array('test' => []));
+        $v = new Validator(array('test' => array()));
         $v->rule('slug', 'test');
         $this->assertFalse($v->validate());
     }

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -616,6 +616,13 @@ class ValidateTest extends BaseTestCase
         $v->rule('slug', 'test');
         $this->assertFalse($v->validate());
     }
+    
+    public function testNoErrorFailOnArray()
+    {
+        $v = new Validator(array('test' => []));
+        $v->rule('slug', 'test');
+        $this->assertFalse($v->validate());
+    }
 
     public function testRegexValid()
     {


### PR DESCRIPTION
If a value is sent in as an array, and you have a slug validation applied to it, you get a php error
this is less than ideal (especially when validating decoded json)

This is a slightly hacky fix for an an issue that stretches across multiple spots in the code - a better fix would probably be an ensure type protected method for anything calling preg_match in the code

I guarantee this hits in other places as well so this is more of a stopgap fix - but I need my code running today :)