### PR TITLE
Invalid argument to foreach 

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -892,7 +892,7 @@ class Validator
         
         // Catches the case where the data isn't an array or object
         if (is_scalar($data)) {
-            return array($data, false);
+            return array(NULL, false);
         }
 
         $identifier = array_shift($identifiers);

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -889,6 +889,11 @@ class Validator
         if (is_array($identifiers) && count($identifiers) === 0) {
             return array($data, false);
         }
+        
+        // Catches the case where the data isn't an array or object
+        if (is_scalar($data)) {
+            return array($data, false);
+        }
 
         $identifier = array_shift($identifiers);
 

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -34,6 +34,13 @@ class ValidateTest extends BaseTestCase
         $v->rule('required', array('name', 'email'));
         $this->assertFalse($v->validate());
     }
+   
+    public function testRequiredSubfieldsArrayStringValue()
+    {
+        $v = new Validator(array('name' => 'bob'));
+        $v->rule('required', array('name.*.red'));
+        $this->assertFalse($v->validate());
+    }
 
     public function testRequiredValid()
     {


### PR DESCRIPTION
a very weird bug that happens when you require a subarray item
but actually pass in a scalar value

PHP throws an "invalid argument to foreach" error

this simply checks that the value in getParts is non-scalar and otherwise returns false