### PR TITLE
Always run 'accepted' validation (#101)

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -945,7 +945,11 @@ class Validator
                 // Don't validate if the field is not required and the value is empty
                 if ($this->hasRule('optional', $field) && isset($values)) {
                     //Continue with execution below if statement
-                } elseif ($v['rule'] !== 'required' && !$this->hasRule('required', $field) && (! isset($values) || $values === '' || ($multiple && count($values) == 0))) {
+                } elseif (
+                    $v['rule'] !== 'required' && !$this->hasRule('required', $field) &&
+                    $v['rule'] !== 'accepted' &&
+                    (! isset($values) || $values === '' || ($multiple && count($values) == 0))
+                ) {
                     continue;
                 }
 

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -98,6 +98,12 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
+    public function testAcceptedNotSet(){
+        $v = new Validator();
+        $v->rule('accepted', 'agree');
+        $this->assertFalse($v->validate());
+    }
+
     public function testNumericValid()
     {
         $v = new Validator(array('num' => '42.341569'));


### PR DESCRIPTION
Fixes a bug where the 'accepted' rule would not run when the field was not required, and not provided, resulting in false positives

See #101 