### PR TITLE
Fixed strict integer rule and added more integer unit tests

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -246,7 +246,7 @@ class Validator
     {
         if (isset($params[0]) && (bool) $params[0]){
             //strict mode
-            return preg_match('/^-?([0-9])+$/i', $value);
+            return preg_match('/^([0-9]|-[1-9]|-?[1-9][0-9]*)$/i', $value);
         }
 
         return filter_var($value, \FILTER_VALIDATE_INT) !== false;

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -143,11 +143,37 @@ class ValidateTest extends BaseTestCase
         $v->rule('integer', 'num');
         $this->assertTrue($v->validate());
 
-
         $v = new Validator(array('num' => '+41243'));
         $v->rule('integer', 'num', true);
         $this->assertFalse($v->validate());
 
+        $v = new Validator(array('num' => '-1'));
+        $v->rule('integer', 'num', true);
+        $this->assertTrue($v->validate());
+
+        $v = new Validator(array('num' => '-0'));
+        $v->rule('integer', 'num', true);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('num' => '0'));
+        $v->rule('integer', 'num', true);
+        $this->assertTrue($v->validate());
+
+        $v = new Validator(array('num' => '+0'));
+        $v->rule('integer', 'num', true);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('num' => '+1'));
+        $v->rule('integer', 'num', true);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('num' => '0123'));
+        $v->rule('integer', 'num', true);
+        $this->assertFalse($v->validate());
+
+        $v = new Validator(array('num' => '-0123'));
+        $v->rule('integer', 'num', true);
+        $this->assertFalse($v->validate());
     }
 
     public function testIntegerInvalid()
@@ -155,7 +181,6 @@ class ValidateTest extends BaseTestCase
         $v = new Validator(array('num' => '42.341569'));
         $v->rule('integer', 'num');
         $this->assertFalse($v->validate());
-
 
         $v = new Validator(array('num' => '--1231'));
         $v->rule('integer', 'num');


### PR DESCRIPTION
The current implementation of the `integer` rule isn't strict when it should be working in `strict` mode.

Examples: `-0`, `0123` and `-0123` aren't values I would expect to be accepted by a strict integer checking rule. One could argue if `-0` is a valid integer. But `0123` and `-0123` are definitely mistakenly accepted values.

The PR accepts the following equivalence classes:

* Natural numbers with one character: `[0-9]`
* Negative two character integers: `-[1-9]`
* Natural numbers with two or more characters and negative integers with three or more characters: `-?[1-9][0-9]*`