### PR TITLE
added nested array support for valdiateEquals and validateDifferent

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -173,9 +173,9 @@ class Validator
      */
     protected function validateEquals($field, $value, array $params)
     {
-        $field2 = $params[0];
-
-        return isset($this->_fields[$field2]) && $value == $this->_fields[$field2];
+        // extract the second field value, this accounts for nested array values
+        list($field2Value, $multiple) = $this->getPart($this->_fields, explode('.', $params[0]));
+        return isset($field2Value) && $value == $field2Value;
     }
 
     /**
@@ -189,9 +189,9 @@ class Validator
      */
     protected function validateDifferent($field, $value, array $params)
     {
-        $field2 = $params[0];
-
-        return isset($this->_fields[$field2]) && $value != $this->_fields[$field2];
+        // extract the second field value, this accounts for nested array values
+        list($field2Value, $multiple) = $this->getPart($this->_fields, explode('.', $params[0]));
+        return isset($field2Value) && $value != $field2Value;
     }
 
     /**

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -80,7 +80,7 @@ class ValidateTest extends BaseTestCase
     public function testEqualsBothNullRequired()
     {
         $v = new Validator(array('foo' => null, 'bar' => null));
-        $v->rule('required', ['foo', 'bar']);
+        $v->rule('required', array('foo', 'bar'));
         $v->rule('equals', 'foo', 'bar');
         $this->assertFalse($v->validate());
     }
@@ -95,7 +95,7 @@ class ValidateTest extends BaseTestCase
     public function testEqualsBothUnsetRequired()
     {
         $v = new Validator(array('foo' => 1));
-        $v->rule('required', ['bar', 'baz']);
+        $v->rule('required', array('bar', 'baz'));
         $v->rule('equals', 'bar', 'baz');
         $this->assertFalse($v->validate());
     }
@@ -124,7 +124,7 @@ class ValidateTest extends BaseTestCase
     public function testDifferentBothNullRequired()
     {
         $v = new Validator(array('foo' => null, 'bar' => null));
-        $v->rule('required', ['foo', 'bar']);
+        $v->rule('required', array('foo', 'bar'));
         $v->rule('equals', 'foo', 'bar');
         $this->assertFalse($v->validate());
     }
@@ -139,7 +139,7 @@ class ValidateTest extends BaseTestCase
     public function testDifferentBothUnsetRequired()
     {
         $v = new Validator(array('foo' => 1));
-        $v->rule('required', ['bar', 'baz']);
+        $v->rule('required', array('bar', 'baz'));
         $v->rule('equals', 'bar', 'baz');
         $this->assertFalse($v->validate());
     }
@@ -1356,7 +1356,7 @@ class ValidateTest extends BaseTestCase
     public function testNestedEqualsBothNullRequired()
     {
         $v = new Validator(array('foo' => array('bar' => null, 'baz' => null)));
-        $v->rule('required', ['foo.bar', 'foo.baz']);
+        $v->rule('required', array('foo.bar', 'foo.baz'));
         $v->rule('equals', 'foo.bar', 'foo.baz');
         $this->assertFalse($v->validate());
     }
@@ -1371,7 +1371,7 @@ class ValidateTest extends BaseTestCase
     public function testNestedEqualsBothUnsetRequired()
     {
         $v = new Validator(array('foo' => 'bar'));
-        $v->rule('required', ['foo.one', 'foo.two']);
+        $v->rule('required', array('foo.one', 'foo.two'));
         $v->rule('equals', 'foo.one', 'foo.two');
         $this->assertFalse($v->validate());
     }
@@ -1400,7 +1400,7 @@ class ValidateTest extends BaseTestCase
     public function testNestedDifferentBothNullRequired()
     {
         $v = new Validator(array('foo' => array('bar' => null, 'baz' => null)));
-        $v->rule('required', ['foo.bar', 'foo.baz']);
+        $v->rule('required', array('foo.bar', 'foo.baz'));
         $v->rule('different', 'foo.bar', 'foo.baz');
         $this->assertFalse($v->validate());
     }
@@ -1415,7 +1415,7 @@ class ValidateTest extends BaseTestCase
     public function testNestedDifferentBothUnsetRequired()
     {
         $v = new Validator(array('foo' => 'bar'));
-        $v->rule('required', ['foo.bar', 'foo.baz']);
+        $v->rule('required', array('foo.bar', 'foo.baz'));
         $v->rule('different', 'foo.bar', 'foo.baz');
         $this->assertFalse($v->validate());
     }

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -1271,6 +1271,34 @@ class ValidateTest extends BaseTestCase
         $v2->rule('required', array('empty_text', 'null_value', 'in_array.empty_text'), true);
         $this->assertTrue($v2->validate());
     }
+
+    public function testNestedEqualsValid()
+    {
+        $v = new Validator(array('foo' => array('one' => 'bar', 'two' => 'bar')));
+        $v->rule('equals', 'foo.one', 'foo.two');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testNestedEqualsInvalid()
+    {
+        $v = new Validator(array('foo' => array('one' => 'bar', 'two' => 'baz')));
+        $v->rule('equals', 'foo.one', 'foo.two');
+        $this->assertFalse($v->validate());
+    }
+
+    public function testNestedDifferentValid()
+    {
+        $v = new Validator(array('foo' => array('one' => 'bar', 'two' => 'baz')));
+        $v->rule('different', 'foo.one', 'foo.two');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testNestedDifferentInvalid()
+    {
+        $v = new Validator(array('foo' => array('one' => 'baz', 'two' => 'baz')));
+        $v->rule('different', 'foo.one', 'foo.two');
+        $this->assertFalse($v->validate());
+    }
 }
 
 function sampleFunctionCallback($field, $value, array $params) {

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -70,6 +70,36 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
+    public function testEqualsBothNull()
+    {
+        $v = new Validator(array('foo' => null, 'bar' => null));
+        $v->rule('equals', 'foo', 'bar');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testEqualsBothNullRequired()
+    {
+        $v = new Validator(array('foo' => null, 'bar' => null));
+        $v->rule('required', ['foo', 'bar']);
+        $v->rule('equals', 'foo', 'bar');
+        $this->assertFalse($v->validate());
+    }
+
+    public function testEqualsBothUnset()
+    {
+        $v = new Validator(array('foo' => 1));
+        $v->rule('equals', 'bar', 'baz');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testEqualsBothUnsetRequired()
+    {
+        $v = new Validator(array('foo' => 1));
+        $v->rule('required', ['bar', 'baz']);
+        $v->rule('equals', 'bar', 'baz');
+        $this->assertFalse($v->validate());
+    }
+
     public function testDifferentValid()
     {
         $v = new Validator(array('foo' => 'bar', 'bar' => 'baz'));
@@ -81,6 +111,36 @@ class ValidateTest extends BaseTestCase
     {
         $v = new Validator(array('foo' => 'baz', 'bar' => 'baz'));
         $v->rule('different', 'foo', 'bar');
+        $this->assertFalse($v->validate());
+    }
+
+    public function testDifferentBothNull()
+    {
+        $v = new Validator(array('foo' => null, 'bar' => null));
+        $v->rule('equals', 'foo', 'bar');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testDifferentBothNullRequired()
+    {
+        $v = new Validator(array('foo' => null, 'bar' => null));
+        $v->rule('required', ['foo', 'bar']);
+        $v->rule('equals', 'foo', 'bar');
+        $this->assertFalse($v->validate());
+    }
+
+    public function testDifferentBothUnset()
+    {
+        $v = new Validator(array('foo' => 1));
+        $v->rule('equals', 'bar', 'baz');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testDifferentBothUnsetRequired()
+    {
+        $v = new Validator(array('foo' => 1));
+        $v->rule('required', ['bar', 'baz']);
+        $v->rule('equals', 'bar', 'baz');
         $this->assertFalse($v->validate());
     }
 
@@ -1286,6 +1346,36 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
+    public function testNestedEqualsBothNull()
+    {
+        $v = new Validator(array('foo' => array('bar' => null, 'baz' => null)));
+        $v->rule('equals', 'foo.bar', 'foo.baz');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testNestedEqualsBothNullRequired()
+    {
+        $v = new Validator(array('foo' => array('bar' => null, 'baz' => null)));
+        $v->rule('required', ['foo.bar', 'foo.baz']);
+        $v->rule('equals', 'foo.bar', 'foo.baz');
+        $this->assertFalse($v->validate());
+    }
+
+    public function testNestedEqualsBothUnset()
+    {
+        $v = new Validator(array('foo' => 'bar'));
+        $v->rule('equals', 'foo.one', 'foo.two');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testNestedEqualsBothUnsetRequired()
+    {
+        $v = new Validator(array('foo' => 'bar'));
+        $v->rule('required', ['foo.one', 'foo.two']);
+        $v->rule('equals', 'foo.one', 'foo.two');
+        $this->assertFalse($v->validate());
+    }
+
     public function testNestedDifferentValid()
     {
         $v = new Validator(array('foo' => array('one' => 'bar', 'two' => 'baz')));
@@ -1299,6 +1389,30 @@ class ValidateTest extends BaseTestCase
         $v->rule('different', 'foo.one', 'foo.two');
         $this->assertFalse($v->validate());
     }
+
+    public function testNestedDifferentBothNull()
+    {
+        $v = new Validator(array('foo' => array('bar' => null, 'baz' => null)));
+        $v->rule('different', 'foo.bar', 'foo.baz');
+        $this->assertTrue($v->validate());
+    }
+
+    public function testNestedDifferentBothNullRequired()
+    {
+        $v = new Validator(array('foo' => array('bar' => null, 'baz' => null)));
+        $v->rule('required', ['foo.bar', 'foo.baz']);
+        $v->rule('different', 'foo.bar', 'foo.baz');
+        $this->assertFalse($v->validate());
+    }
+
+    public function testNestedDifferentBothUnsetRequired()
+    {
+        $v = new Validator(array('foo' => 'bar'));
+        $v->rule('required', ['foo.bar', 'foo.baz']);
+        $v->rule('different', 'foo.bar', 'foo.baz');
+        $this->assertFalse($v->validate());
+    }
+
 }
 
 function sampleFunctionCallback($field, $value, array $params) {

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -1405,6 +1405,13 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
+    public function testNestedDifferentBothUnset()
+    {
+        $v = new Validator(array('foo' => 'bar'));
+        $v->rule('different', 'foo.bar', 'foo.baz');
+        $this->assertTrue($v->validate());
+    }
+
     public function testNestedDifferentBothUnsetRequired()
     {
         $v = new Validator(array('foo' => 'bar'));


### PR DESCRIPTION
Hey there,

Great validation library, I really appreciate the usability and simplicity of it all! I've been using this for a bit and I've been sending it nested arrays decoded from my json api directly and I found that the equals and different methods weren't working for nested array elements. I made a quick fix that utilizes your existing helper function to extract the value from the second argument, as before it was using the name of the second item directly and therefore the isset($this->_fields[$field2]) would always evaluate to false when passing a nested array item (i.e. 'object.itemTwo'). I added four new tests that mimic your existing tests for these methods, but with nested arrays and everything looks good. I tested with more depth to the arrays and that appears to be fine as well. Let me know if you have any questions or comments. Thanks again for a great library!

Best,
Tom