### PR TITLE
Added option to stop validation when a rule is failed

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -1021,9 +1021,8 @@ class Validator
      * Should the validation stop a rule is failed
      * @param bool $stop
      */
-    public function stopOnFirstFail($stop) {
-    	if(!is_bool($stop)) throw new \InvalidArgumentException('Parameter of type boolean expected');
-    	$this->stop_on_first_fail = $stop;
+    public function stopOnFirstFail($stop = true) {
+    	$this->stop_on_first_fail = (bool) $stop;
     }
 
     /**

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -1021,7 +1021,8 @@ class Validator
      * Should the validation stop a rule is failed
      * @param bool $stop
      */
-    public function stopOnFirstFail(bool $stop) {
+    public function stopOnFirstFail($stop) {
+    	if(!is_bool($stop)) throw new \InvalidArgumentException('Parameter of type boolean expected');
     	$this->stop_on_first_fail = $stop;
     }
 

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -78,6 +78,11 @@ class Validator
     protected $validUrlPrefixes = array('http://', 'https://', 'ftp://');
 
     /**
+     * @var bool
+     */
+    protected $stop_on_first_fail = false;
+
+    /**
      * Setup validation
      *
      * @param  array                     $data
@@ -965,6 +970,7 @@ class Validator
      */
     public function validate()
     {
+    	$set_to_break = false;
         foreach ($this->_validations as $v) {
             foreach ($v['fields'] as $field) {
                  list($values, $multiple) = $this->getPart($this->_fields, explode('.', $field));
@@ -999,11 +1005,24 @@ class Validator
 
                 if (!$result) {
                     $this->error($field, $v['message'], $v['params']);
+                    if($this->stop_on_first_fail) {
+                    	$set_to_break = true;
+                    	break;
+                    }
                 }
             }
+            if($set_to_break) break;
         }
 
         return count($this->errors()) === 0;
+    }
+
+    /**
+     * Should the validation stop a rule is failed
+     * @param bool $stop
+     */
+    public function stopOnFirstFail(bool $stop) {
+    	$this->stop_on_first_fail = $stop;
     }
 
     /**

--- a/tests/Valitron/StopOnFirstFailTest.php
+++ b/tests/Valitron/StopOnFirstFailTest.php
@@ -1,0 +1,28 @@
+<?php
+use Valitron\Validator;
+
+
+class StopOnFirstFail extends BaseTestCase {
+
+	public function testStopOnFirstFail() {
+		$rules = array(
+			'myField1' => array(
+				array('lengthMin', 5, 'message'=>'myField1 must be 5 characters minimum'),
+				array('url', 'message' => 'myField1 is not a valid url'),
+				array('urlActive', 'message' => 'myField1 is not an active url')
+			)
+		);
+
+		$v = new Validator(array(
+			'myField1' => 'myVal'
+		));
+
+		$v->mapFieldsRules($rules);
+		$v->stopOnFirstFail(true);
+		$this->assertFalse($v->validate());
+
+		$errors = $v->errors();
+		$this->assertCount(1, $errors['myField1']);
+	}
+
+}


### PR DESCRIPTION
I added an option to the validation class to allow the user stop the validation process if a rule fails in the case where a rule depends on previous rules to be passed.

Usage example: 
```php
$rules = array(
	'myField1' => array(
		array('lengthMin', 5, 'message'=>'myField1 must be 5 characters minimum'),
		array('url', 'message' => 'myField1 is not a valid url'),
		array('urlActive', 'message' => 'myField1 is not an active url')
	)
);

$v = new Validator(array(
	'myField1' => 'myVal'
));

$v->mapFieldsRules($rules);
$v->stopOnFirstFail(true);

if($v->validate()) {
	// Add to db, make API calls, etc
}
else {
	$errors = $v->errors();
	// $errors = array('myField1' => array('myField1 is not a valid url'));
}
```

PS: Credit card tests are failing.