### PR TITLE
Add some validation to prevent PHP Warning when value in subset valid…

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -489,7 +489,7 @@ class Validator
         if (!is_array($params[0])) {
             $params[0] = array($params[0]);
         }
-        if (is_scalar($value)) {
+        if (is_scalar($value) || is_null($value)) {
             return $this->validateIn($field, $value, $params);
         }
 

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -484,7 +484,7 @@ class ValidateTest extends BaseTestCase
         $v->rule('lengthMin', 'str', 4);
         $this->assertTrue($v->validate());
     }
-    
+
     public function testLengthMinValidAltSyntax()
     {
         $v = new Valitron\Validator(array('username' => 'martha'));
@@ -1717,6 +1717,15 @@ class ValidateTest extends BaseTestCase
         // rule value not specified
         $v = new Validator(array('test_field' => array('black', 45)));
         $v->rule('subset', 'test_field');
+        $this->assertFalse($v->validate());
+    }
+
+    public function testSubsetAcceptNullValue()
+    {
+    		// rule value equals null
+        $v = new Validator(array('test_field' => null));
+        $v->rule('required', 'test_field');
+        $v->rule('subset', 'test_field', array('black', 45));
         $this->assertFalse($v->validate());
     }
 


### PR DESCRIPTION
Add some validation because when use for example to validate api schema and value send through request is null but exists, when try to do the array_intersect throws an exception.

So for that reason add validation before where ask is value is null and if is it send to another validation ArrayIn.

Thanks for the review and probably merge.

Greetings