### PR TITLE
Fix invalid opening bracket for arrayHasKeys example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ $v = new Valitron\Validator([
         'city' => 'Doe D.C.'
     ]
 ]);
-$v->rule(['arrayHasKeys', 'address', ['name', 'street', 'city']);
+$v->rule('arrayHasKeys', 'address', ['name', 'street', 'city']);
 $v->validate();
 ```
 


### PR DESCRIPTION
The `arrayHasKeys` rule example in the README has an invalid opening `[` in the call to `rule()`. This PR removes it.