### PR TITLE
Allow disabling of auto prepending the field labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,33 @@ V::lang('ar');
 
 ```
 
+Disabling the {field} name in the output of the error message. 
+
+```php
+use Valitron\Validator as V;
+
+$v = new Valitron\Validator(['name' => 'John']);
+$v->rule('required', ['name']);
+
+// Disable prepending the labels
+$v->setPrependLabels(false);
+
+// Error output for the "false" condition
+[
+    ["name"] => [
+        "is required"
+    ]
+]
+
+// Error output for the default (true) condition
+[
+    ["name"] => [
+        "name is required"
+    ]
+]
+
+```
+
 You can conditionally require values using required conditional rules. In this example, for authentication, we're requiring either a token when both the email and password are not present, or a password when the email address is present.
 ```php
 // this rule set would work for either data set...

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -84,6 +84,11 @@ class Validator
     protected $stop_on_first_fail = false;
 
     /**
+     * @var bool
+     */
+    protected $prepend_labels = true;
+
+    /**
      * Setup validation
      *
      * @param  array $data
@@ -142,6 +147,14 @@ class Validator
         }
 
         return static::$_langDir ?: dirname(dirname(__DIR__)) . '/lang';
+    }
+
+    /**
+     * @param bool $prepend_labels
+     */
+    public function prependLabels($prepend_labels = true)
+    {
+        $this->prepend_labels = $prepend_labels;
     }
 
     /**
@@ -900,6 +913,12 @@ class Validator
         return false;
     }
 
+    /**
+     * @param $field
+     * @param $value
+     * @param $params
+     * @return bool
+     */
     protected function validateInstanceOf($field, $value, $params)
     {
         $isInstanceOf = false;
@@ -1022,6 +1041,12 @@ class Validator
         return true;
     }
 
+    /**
+     * @param $field
+     * @param $value
+     * @param $params
+     * @return bool
+     */
     protected function validateArrayHasKeys($field, $value, $params)
     {
         if (!is_array($value) || !isset($params[0])) {
@@ -1124,6 +1149,12 @@ class Validator
         $this->_labels = array();
     }
 
+    /**
+     * @param $data
+     * @param $identifiers
+     * @param bool $allow_empty
+     * @return array
+     */
     protected function getPart($data, $identifiers, $allow_empty = false)
     {
         // Catches the case where the field is an array of discrete values
@@ -1167,6 +1198,13 @@ class Validator
         }
     }
 
+    /**
+     * @param $validation
+     * @param $field
+     * @param $values
+     * @param $multiple
+     * @return bool
+     */
     private function validationMustBeExcecuted($validation, $field, $values, $multiple){
         //always excecute requiredWith(out) rules
         if (in_array($validation['rule'], array('requiredWith', 'requiredWithout'))){
@@ -1288,6 +1326,9 @@ class Validator
         return false;
     }
 
+    /**
+     * @param $callback
+     */
     protected static function assertRuleCallback($callback)
     {
         if (!is_callable($callback)) {
@@ -1471,7 +1512,9 @@ class Validator
                 }
             }
         } else {
-            $message = str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $message);
+            $message = $this->prepend_labels
+                ? str_replace('{field}', ucwords(str_replace('_', ' ', $field)), $message)
+                : str_replace('{field} ', '', $message);
         }
 
         return $message;

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -913,12 +913,6 @@ class Validator
         return false;
     }
 
-    /**
-     * @param $field
-     * @param $value
-     * @param $params
-     * @return bool
-     */
     protected function validateInstanceOf($field, $value, $params)
     {
         $isInstanceOf = false;
@@ -1041,12 +1035,6 @@ class Validator
         return true;
     }
 
-    /**
-     * @param $field
-     * @param $value
-     * @param $params
-     * @return bool
-     */
     protected function validateArrayHasKeys($field, $value, $params)
     {
         if (!is_array($value) || !isset($params[0])) {
@@ -1149,12 +1137,6 @@ class Validator
         $this->_labels = array();
     }
 
-    /**
-     * @param $data
-     * @param $identifiers
-     * @param bool $allow_empty
-     * @return array
-     */
     protected function getPart($data, $identifiers, $allow_empty = false)
     {
         // Catches the case where the field is an array of discrete values
@@ -1198,13 +1180,6 @@ class Validator
         }
     }
 
-    /**
-     * @param $validation
-     * @param $field
-     * @param $values
-     * @param $multiple
-     * @return bool
-     */
     private function validationMustBeExcecuted($validation, $field, $values, $multiple){
         //always excecute requiredWith(out) rules
         if (in_array($validation['rule'], array('requiredWith', 'requiredWithout'))){
@@ -1326,9 +1301,6 @@ class Validator
         return false;
     }
 
-    /**
-     * @param $callback
-     */
     protected static function assertRuleCallback($callback)
     {
         if (!is_callable($callback)) {

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -152,7 +152,7 @@ class Validator
     /**
      * @param bool $prepend_labels
      */
-    public function prependLabels($prepend_labels = true)
+    public function setPrependLabels($prepend_labels = true)
     {
         $this->prepend_labels = $prepend_labels;
     }

--- a/tests/Valitron/ErrorMessagesTest.php
+++ b/tests/Valitron/ErrorMessagesTest.php
@@ -12,6 +12,19 @@ class ErrorMessagesTest extends BaseTestCase
         $this->assertSame(array("Name is required"), $v->errors('name'));
     }
 
+    /**
+     * Test the disabling of prepending the field labels
+     * to error messages.
+     */
+    public function testErrorMessageExcludeFieldName()
+    {
+        $v = new Validator(array());
+        $v->setPrependLabels(false);
+        $v->rule('required', 'name');
+        $v->validate();
+        $this->assertSame(array("is required"), $v->errors('name'));
+    }
+
     public function testAccurateErrorMessageParams()
     {
         $v = new Validator(array('num' => 5));


### PR DESCRIPTION
Created a new setter to disable the prepending of field labels that are outputted in the error messages.

By default it's condition is `true` so it's backwards compatible.