### PR TITLE
Index error by rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,31 @@ $v->setPrependLabels(false);
 
 ```
 
+Allowing indexing of error messages by the name of the rule.
+
+```php
+$v = new Valitron\Validator(['name' => 'John']);
+$v->rule('required', ['name']);
+
+// Enable indexing of error messages
+$v->setIndexErrorByRule(true);
+
+// Error output for the default (false) condition
+[
+    ["name"] => [
+        "Name is required"
+    ]
+]
+
+// Error output for the "true" condition
+[
+    ["name"] => [
+        "required" => "Name is required"
+    ]
+]
+
+```
+
 You can conditionally require values using required conditional rules. In this example, for authentication, we're requiring either a token when both the email and password are not present, or a password when the email address is present.
 ```php
 // this rule set would work for either data set...

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -89,6 +89,11 @@ class Validator
     protected $prepend_labels = true;
 
     /**
+     * @var bool
+     */
+    protected $index_error_by_rule = false;
+
+    /**
      * Setup validation
      *
      * @param  array $data
@@ -155,6 +160,14 @@ class Validator
     public function setPrependLabels($prepend_labels = true)
     {
         $this->prepend_labels = $prepend_labels;
+    }
+
+    /**
+     * @param bool $index_error_by_rule
+     */
+    public function setIndexErrorByRule($index_error_by_rule = true)
+    {
+        $this->index_error_by_rule = $index_error_by_rule;
     }
 
     /**
@@ -1082,9 +1095,10 @@ class Validator
      *
      * @param string $field
      * @param string $message
-     * @param array  $params
+     * @param array $params
+     * @param string|null $rule
      */
-    public function error($field, $message, array $params = array())
+    public function error($field, $message, array $params = array(), $rule = null)
     {
         $message = $this->checkAndSetLabel($field, $message, $params);
 
@@ -1110,7 +1124,12 @@ class Validator
             $values[] = $param;
         }
 
-        $this->_errors[$field][] = vsprintf($message, $values);
+        $error = vsprintf($message, $values);
+        if ($this->index_error_by_rule && $rule !== null) {
+            $this->_errors[$field][$rule] = $error;
+        } else {
+            $this->_errors[$field][] = $error;
+        }
     }
 
     /**
@@ -1237,7 +1256,7 @@ class Validator
                 }
 
                 if (!$result) {
-                    $this->error($field, $v['message'], $v['params']);
+                    $this-> error($field, $v['message'], $v['params'], $v['rule']);
                     if ($this->stop_on_first_fail) {
                         $set_to_break = true;
                         break;
@@ -1467,7 +1486,7 @@ class Validator
      * @param  string $field
      * @param  string $message
      * @param  array  $params
-     * @return array
+     * @return string
      */
     protected function checkAndSetLabel($field, $message, $params)
     {

--- a/tests/Valitron/IndexErrorByRuleTest.php
+++ b/tests/Valitron/IndexErrorByRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Valitron\Validator;
+
+class IndexErrorByRuleTest extends BaseTestCase
+{
+    public function testErrorMessageIsIndexedByNumberByDefault()
+    {
+        $v = new Validator(array());
+        $v->rule('required', 'name');
+        $v->validate();
+        $this->assertSame(array("Name is required"), $v->errors('name'));
+    }
+
+    public function testErrorMessageIsIndexedByRuleName()
+    {
+        $v = new Validator(array());
+        $v->setIndexErrorByRule(/*true*/);
+        $v->rule('required', 'name');
+        $v->validate();
+        $this->assertSame(array("required" => "Name is required"), $v->errors('name'));
+    }
+
+    public function testDisableIndexByRuleName()
+    {
+        $v = new Validator(array());
+        $v->setIndexErrorByRule(false);
+        $v->rule('required', 'name');
+        $v->validate();
+        $this->assertSame(array("Name is required"), $v->errors('name'));
+    }
+
+    public function testFieldWithSeveralMessages()
+    {
+        $v = new Validator(array('name' => 'Joe'));
+        $v->setIndexErrorByRule(/*true*/);
+        $v->rule('length', 'name', 5);
+        $v->rule('lengthMin', 'name', 10);
+        $v->rule('lengthMax', 'name', 1);
+        $v->validate();
+        $this->assertSame(
+            array(
+                'length' => 'Name must be 5 characters long',
+                'lengthMin' => 'Name must be at least 10 characters long',
+                'lengthMax' => 'Name must not exceed 1 characters'
+            ),
+            $v->errors('name')
+        );
+    }
+}


### PR DESCRIPTION
Sometimes it is useful to have not only the error message, but also the name of the rule that was violated. The name of the rule can be used as an error code for easier processing by the client.