### PR TITLE
Fixed #335 - ValidateTest::testNotInInvalidAltSyntax has no assertions

### DIFF
--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -972,6 +972,9 @@ class ValidateTest extends BaseTestCase
         $this->assertFalse($v->validate());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testNotInInvalidAltSyntax()
     {
         $v = new Valitron\Validator(array('color' => 'yellow'));


### PR DESCRIPTION
Fixed #335 - this adds an annotation to the test to inform PHPUnit that the test does not have any assertions.