### PR TITLE
Update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ methods with a focus on readable and concise syntax. Valitron is the
 simple and pragmatic validation library you've been looking for.
 
 [![Build
-Status](https://travis-ci.org/vlucas/valitron.png?branch=master)](https://travis-ci.org/vlucas/valitron)
+Status](https://github.com/vlucas/valitron/actions/workflows/test.yml/badge.svg)](https://github.com/vlucas/valitron/actions/workflows/test.yml)
 [![Latest Stable Version](https://poser.pugx.org/vlucas/valitron/v/stable.png)](https://packagist.org/packages/vlucas/valitron)
 [![Total Downloads](https://poser.pugx.org/vlucas/valitron/downloads.png)](https://packagist.org/packages/vlucas/valitron)
 


### PR DESCRIPTION
As GitHub Actions now runs CI, the build status badge must be from GitHub Actions.