### PR TITLE
php8: avoid named parameters in call_user_func_array

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -1507,7 +1507,7 @@ class Validator
                         $innerParams = (array)$innerParams;
                     }
                     array_unshift($innerParams, $ruleType);
-                    call_user_func_array(array($this, 'rule'), $innerParams);
+                    call_user_func_array(array($this, 'rule'), array_values($innerParams));
                 }
             } else {
                 $this->rule($ruleType, $params);
@@ -1555,7 +1555,7 @@ class Validator
                 unset($rule['message']);
             }
             //Add the field and additional parameters to the rule
-            $added = call_user_func_array(array($me, 'rule'), array_merge(array($ruleName, $field), $rule));
+            $added = call_user_func_array(array($me, 'rule'), array_values(array_merge(array($ruleName, $field), $rule)));
             if (!empty($message)) {
                 $added->message($message);
             }


### PR DESCRIPTION
I just ran into this issue in another project while evaluating PHP 8 support.

https://php.watch/versions/8.0/named-parameters#named-params-call_user_func_array

PHP 8 supports named parameters and call_user_func_array uses that when the parameter array has keys.

I don't know if the "array_values" solution is needed in Valitron or not but I thought I would share just in case.