### PR TITLE
Update es.php error message as it's currently incorrect

### DIFF
--- a/lang/es.php
+++ b/lang/es.php
@@ -7,7 +7,7 @@ return array(
     'accepted'       => "debe ser aceptado",
     'numeric'        => "debe ser numérico",
     'integer'        => "debe ser un entero",
-    'length'         => "debe ser mas largo de %d",
+    'length'         => "debe tener exactamente %d caracteres",
     'min'            => "debe ser mayor de %s",
     'max'            => "debe ser menor de %s",
     'in'             => "contiene un valor inválido",


### PR DESCRIPTION
`length` rule matches exact character length.
Current spanish error roughly translates to `must be longer than %d` which is wrong.
Proposed `debe tener exactamente %d caracteres` translates to `must have exactly %d characters`.