### PR TITLE
Fixes an issue boolean false set on deterministic fields are treated unexpectedly in requireWith and requireWithout validators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ $v->validate();
 ```
 
 ## requiredWith fields usage
-The `requiredWith` rule checks that the field is required, not null, and not the empty string, if any other fields are present, not null, and not the empty string.
+The `requiredWith` rule checks that the field is required, not null, and not an empty string, if any other fields are present, not null, not boolean false, and not an empty string.
 ```php
 // password field will be required when the username field is provided and not empty
 $v->rule('requiredWith', 'password', 'username');
@@ -290,7 +290,7 @@ $v->validate();
 ```
 
 ### Strict flag
-The strict flag will change the `requiredWith` rule to `requiredWithAll` which will require the field only if ALL of the other fields are present, not null, and not the empty string.
+The strict flag will change the `requiredWith` rule to `requiredWithAll` which will require the field only if all the other fields are present, not null, and not an empty string.
 ```php
 // in this example the suffix field is required only when both the first_name and last_name are provided
 $v->rule('requiredWith', 'suffix', ['first_name', 'last_name'], true);
@@ -306,7 +306,7 @@ $v->rules([
 $v->validate();
 ```
 
-Likewise, in this case `validate()` would still return true, as the suffix field would not be required in strict mode, as not all of the fields are provided.
+Likewise, in this case `validate()` would still return true, as the suffix field would not be required in strict mode, as not all the fields are provided.
 ```php
 $v = new Valitron\Validator(['first_name' => 'steve']);
 $v->rules([
@@ -317,8 +317,31 @@ $v->rules([
 $v->validate();
 ```
 
+### Check Boolean Flag
+The check boolean flag will enable the rule to work if the conditional field(s) are set too (bool)false. When not enabled, a (bool)false is treated as "SET" and would require the specified fields. Since this parameter comes after the strict flag, you must also set the strict flag to `true` or `false` when enabling the check boolean flag.
+```php
+// in this example the 'suffix' field is not required when the 'enabled' is included in the data and set to 
+// (bool)false. Without enabling the check boolean flag, this scenario would result in 'suffix' being required.
+$v->rule('requiredWith', 'suffix', 'enabled', false, true);
+
+// we can still use the strict flag as described when providing multiple fields; in this case,
+// setting fields 'hidden' AND 'enabled' to (bool)true would make 'suffix' required but if either
+// was set to (bool)false then 'suffix' would not be required when it previously would be.
+$v->rule('requiredWith', 'suffix', ['enabled', 'hidden'], true, true);
+```
+Alternate syntax.
+```php
+$v = new Valitron\Validator(['first_name' => 'steve', 'last_name' => 'holt', 'suffix' => 'Mr']);
+$v->rules([
+    'requiredWith' => [
+        ['suffix', ['first_name', 'last_name'], true]
+    ]
+]);
+$v->validate();
+```
+
 ## requiredWithout fields usage
-The `requiredWithout` rule checks that the field is required, not null, and not the empty string, if any other fields are NOT present.
+The `requiredWithout` rule checks that the field is required, not null, and not an empty string, if any other fields are NOT present.
 ```php
 // this rule will require the username field when the first_name is not present
 $v->rule('requiredWithout', 'username', 'first_name')
@@ -355,7 +378,7 @@ $v->validate();
 ```
 
 ### Strict flag
-The strict flag will change the `requiredWithout` rule to `requiredWithoutAll` which will require the field only if ALL of the other fields are not present.
+The strict flag will change the `requiredWithout` rule to `requiredWithoutAll` which will require the field only if all the other fields are not present.
 ```php
 // in this example the username field is required only when both the first_name and last_name are not provided
 $v->rule('requiredWithout', 'username', ['first_name', 'last_name'], true);
@@ -371,12 +394,35 @@ $v->rules([
 $v->validate();
 ```
 
-Likewise, in this case `validate()` would still return true, as the username field would not be required in strict mode, as all of the fields are provided.
+Likewise, in this case `validate()` would still return true, as the username field would not be required in strict mode, as all fields are provided.
 ```php
 $v = new Valitron\Validator(['first_name' => 'steve', 'last_name' => 'holt']);
 $v->rules([
     'requiredWithout' => [
         ['suffix', ['first_name', 'last_name'], true]
+    ]
+]);
+$v->validate();
+```
+
+### Check Boolean Flag
+The check boolean flag will enable the rule to work if the conditional field is set to (bool)false. When not enabled, a (bool)false on the conditional field(s) are treated as "SET" and would require the specified fields. Since this parameter comes after the strict flag, you must also set the strict flag to `true` or `false` when enabling the check boolean flag.
+```php
+// in this example the 'mothers_name' field is required if the 'is_adult' field is included and set to (bool)false.
+// Without enabling the check boolean flag, this scenario would result in mothers_name not being required.
+$v->rule('requiredWithout', 'mothers_name', 'is_adult', false, true);
+
+// we can still use the strict flag as described when providing multiple fields; in this case,
+// setting fields 'is_adult' AND 'is_orphan' to (bool)false would make mothers_name required but if either
+// was set to (bool)true then 'mothers_name' would not be required when it previously would be.
+$v->rule('requiredWithout', 'mothers_name', ['is_adult', 'is_orphan'], true, true);
+```
+Alternate syntax.
+```php
+$v = new Valitron\Validator(['mothers_name' => 'Sharon Marsh', 'is_adult' => false, 'is_orphan' => false]);
+$v->rules([
+    'requiredWithout' => [
+        ['mothers_name', ['is_adult', 'is_orphan'], true, true] 
     ]
 ]);
 $v->validate();

--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -426,7 +426,7 @@ class Validator
         }
 
         if ($forceAsAssociative || $this->isAssociativeArray($params[0])) {
-           $params[0] = array_keys($params[0]);
+            $params[0] = array_keys($params[0]);
         }
 
         $strict = false;
@@ -939,7 +939,7 @@ class Validator
     }
 
     /**
-     * Validates whether or not a field is required based on whether or not other fields are present.
+     * Validates whether a field is required based on whether other fields are present.
      *
      * @param string $field name of the field in the data array
      * @param mixed $value value of this field
@@ -956,11 +956,19 @@ class Validator
             $reqParams = is_array($params[0]) ? $params[0] : array($params[0]);
             // check for the flag indicating if all fields are required
             $allRequired = isset($params[1]) && (bool)$params[1];
+            // check for the flag indicating if boolean value on the required field should be accounted for
+            $checkBool = isset($params[2]) && (bool)$params[2];
             $emptyFields = 0;
             foreach ($reqParams as $requiredField) {
-                // check the field is set, not null, and not the empty string
-                if (isset($fields[$requiredField]) && !is_null($fields[$requiredField])
-                    && (is_string($fields[$requiredField]) ? trim($fields[$requiredField]) !== '' : true)) {
+                // check the field is set, not null, not boolean false (when flag enabled), and not an empty string
+//                if (isset($fields[$requiredField]) && !is_null($fields[$requiredField])
+//                    && (is_string($fields[$requiredField]) ? trim($fields[$requiredField]) !== '' : true)) {
+                if (isset($fields[$requiredField]) && !is_null($fields[$requiredField]) &&
+                    (
+                        (is_string($fields[$requiredField]) ? trim($fields[$requiredField]) !== '' : true) &&
+                        !($checkBool && is_bool($fields[$requiredField]) && $fields[$requiredField] === false) // Boolean false check when enabled
+                    )) {
+
                     if (!$allRequired) {
                         $conditionallyReq = true;
                         break;
@@ -983,7 +991,7 @@ class Validator
     }
 
     /**
-     * Validates whether or not a field is required based on whether or not other fields are present.
+     * Validates whether a field is required based on whether other fields are present.
      *
      * @param string $field name of the field in the data array
      * @param mixed $value value of this field
@@ -1000,11 +1008,17 @@ class Validator
             $reqParams = is_array($params[0]) ? $params[0] : array($params[0]);
             // check for the flag indicating if all fields are required
             $allEmpty = isset($params[1]) && (bool)$params[1];
+            // check for the flag indicating if boolean value on the required field should be accounted for
+            $checkBool = isset($params[2]) && (bool)$params[2];
             $filledFields = 0;
             foreach ($reqParams as $requiredField) {
-                // check the field is NOT set, null, or the empty string, in which case we are requiring this value be present
-                if (!isset($fields[$requiredField]) || (is_null($fields[$requiredField])
-                    || (is_string($fields[$requiredField]) && trim($fields[$requiredField]) === ''))) {
+                // check the field is NOT set, null, an empty string, or boolean false (when $checkBool flag is set),
+                // in which case we are requiring this value be present
+                if (!isset($fields[$requiredField]) || is_null($fields[$requiredField]) ||
+                    (is_string($fields[$requiredField]) ? trim($fields[$requiredField]) === '' : true) ||
+                    ($checkBool && is_bool($fields[$requiredField]) && $fields[$requiredField] === false) // Boolean false check when enabled
+                ) {
+
                     if (!$allEmpty) {
                         $conditionallyReq = true;
                         break;

--- a/tests/Valitron/ValidateAddInstanceRuleTest.php
+++ b/tests/Valitron/ValidateAddInstanceRuleTest.php
@@ -115,6 +115,6 @@ class ValidateAddInstanceRuleTest extends BaseTestCase
         $v->addInstanceRule("foo_rule", function () {
         });
         $u = $v->getUniqueRuleName("foo");
-        $this->assertRegExp("/^foo_rule_[0-9]{1,5}$/", $u);
+        $this->assertMatchesRegularExpression("/^foo_rule_[0-9]{1,5}$/", $u);
     }
 }

--- a/tests/Valitron/ValidateTest.php
+++ b/tests/Valitron/ValidateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\ExpectationFailedException;
 use Valitron\Validator;
 
 class ValidateTest extends BaseTestCase
@@ -2121,11 +2122,11 @@ class ValidateTest extends BaseTestCase
 
     public function testCreditCardValid()
     {
-        $visa = array(4539511619543489, 4532949059629052, 4024007171194938, 4929646403373269, 4539135861690622);
-        $mastercard = array(5162057048081965, 5382687859049349, 5484388880142230, 5464941521226434, 5473481232685965, 2223000048400011, 2223520043560014);
-        $amex = array(371442067262027, 340743030537918, 345509167493596, 343665795576848, 346087552944316);
-        $dinersclub = array(30363194756249, 30160097740704, 38186521192206, 38977384214552, 38563220301454);
-        $discover = array(6011712400392605, 6011536340491809, 6011785775263015, 6011984124619056, 6011320958064251);
+        $visa = array('4539511619543489', '4532949059629052', '4024007171194938', '4929646403373269', '4539135861690622');
+        $mastercard = array('5162057048081965', '5382687859049349', '5484388880142230', '5464941521226434', '5473481232685965', '2223000048400011', '2223520043560014');
+        $amex = array('371442067262027', '340743030537918', '345509167493596', '343665795576848', '346087552944316');
+        $dinersclub = array('30363194756249', '30160097740704', '38186521192206', '38977384214552', '38563220301454');
+        $discover = array('6011712400392605', '6011536340491809', '6011785775263015', '6011984124619056', '6011320958064251');
 
         foreach (compact('visa', 'mastercard', 'amex', 'dinersclub', 'discover') as $type => $numbers) {
             foreach ($numbers as $number) {
@@ -2145,11 +2146,11 @@ class ValidateTest extends BaseTestCase
 
     public function testCreditCardInvalid()
     {
-        $visa = array(3539511619543489, 3532949059629052, 3024007171194938, 3929646403373269, 3539135861690622);
-        $mastercard = array(4162057048081965, 4382687859049349, 4484388880142230, 4464941521226434, 4473481232685965);
-        $amex = array(271442067262027, 240743030537918, 245509167493596, 243665795576848, 246087552944316);
-        $dinersclub = array(20363194756249, 20160097740704, 28186521192206, 28977384214552, 28563220301454);
-        $discover = array(5011712400392605, 5011536340491809, 5011785775263015, 5011984124619056, 5011320958064251);
+        $visa = array('3539511619543489', '3532949059629052', '3024007171194938', '3929646403373269', '3539135861690622');
+        $mastercard = array('4162057048081965', '4382687859049349', '4484388880142230', '4464941521226434', '4473481232685965');
+        $amex = array('271442067262027', '240743030537918', '245509167493596', '243665795576848', '246087552944316');
+        $dinersclub = array('20363194756249', '20160097740704', '28186521192206', '28977384214552', '28563220301454');
+        $discover = array('5011712400392605', '5011536340491809', '5011785775263015', '5011984124619056', '5011320958064251');
 
         foreach (compact('visa', 'mastercard', 'amex', 'dinersclub', 'discover') as $type => $numbers) {
             foreach ($numbers as $number) {
@@ -2531,6 +2532,357 @@ class ValidateTest extends BaseTestCase
         $this->assertTrue($v->validate());
     }
 
+
+    
+    // REPEAT SAME EXACT TESTS for requiredWith AND requiredWithout, BUT WITH CHECK BOOLEAN ENABLED
+    // TO VERIFY BACKWARD COMPATIBILITY.
+    // Begin Check Boolean tests for requiredWith and requiredWithout
+
+    public function testRequiredWithCheckBooleanValid()
+    {
+        $v = new Validator(array('username' => 'tester', 'password' => 'mypassword'));
+        $v->rule('requiredWith', 'password', 'username', false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanValidNoParams()
+    {
+        $v = new Validator(array());
+        $v->rule('requiredWith', 'password', 'username', false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanValidEmptyString()
+    {
+        $v = new Validator(array('username' => ''));
+        $v->rule('requiredWith', 'password', 'username', false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanValidNullValue()
+    {
+        $v = new Validator(array('username' => null));
+        $v->rule('requiredWith', 'password', 'username', false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanValidAltSyntax()
+    {
+        $v = new Validator(array('username' => 'tester', 'password' => 'mypassword'));
+        $v->rules(array(
+            'requiredWith' => array(
+                array('password', 'username', false, true)
+            )
+        ));
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanValidArray()
+    {
+        $v = new Validator(array('username' => 'tester', 'email' => 'test@test.com', 'password' => 'mypassword'));
+        $v->rule('requiredWith', 'password', array('username', 'email'), false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanStrictValidArray()
+    {
+        $v = new Validator(array('username' => 'tester', 'email' => 'test@test.com', 'password' => 'mypassword'));
+        $v->rule('requiredWith', 'password', array('username', 'email'), true, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanStrictInvalidArray()
+    {
+        $v = new Validator(array('email' => 'test@test.com', 'username' => 'batman'));
+        $v->rule('requiredWith', 'password', array('username', 'email'), true, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanStrictValidArrayNotRequired()
+    {
+        $v = new Validator(array('username' => 'tester', 'email' => 'test@test.com'));
+        $v->rule('requiredWith', 'password', array('username', 'email', 'nickname'), true, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanStrictValidArrayEmptyValues()
+    {
+        $v = new Validator(array('email' => '', 'username' => null));
+        $v->rule('requiredWith', 'password', array('username', 'email'), true, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanStrictInvalidArraySingleValue()
+    {
+        $v = new Validator(array('email' => 'tester', 'username' => null));
+        $v->rule('requiredWith', 'password', array('username', 'email'), true, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanValidArrayAltSyntax()
+    {
+        $v = new Validator(array('password' => 'mypassword'));
+        $v->rules(array(
+            'requiredWith' => array(
+                array('password', array('username', 'email'), false, true)
+            )
+        ));
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanInvalid()
+    {
+        $v = new Validator(array('username' => 'tester'));
+        $v->rule('requiredWith', 'password', 'username', false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanInvalidAltSyntax()
+    {
+        $v = new Validator(array('username' => 'tester'));
+        $v->rules(array(
+            'requiredWith' => array(
+                array('password', 'username', false, true)
+            )
+        ));
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanInvalidArray()
+    {
+        $v = new Validator(array('email' => 'test@test.com', 'nickname' => 'kevin'));
+        $v->rule('requiredWith', 'password', array('username', 'email', 'nickname'), false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanInvalidStrictArray()
+    {
+        $v = new Validator(array('email' => 'test@test.com', 'username' => 'batman', 'nickname' => 'james'));
+        $v->rule('requiredWith', 'password', array('username', 'email', 'nickname'), true, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanInvalidArrayAltSyntax()
+    {
+        $v = new Validator(array('username' => 'tester', 'email' => 'test@test.com'));
+        $v->rules(array(
+            'requiredWith' => array(
+                array('password', array('username', 'email', 'nickname'), false, true)
+            )
+        ));
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanStrictInvalidArrayAltSyntax()
+    {
+        $v = new Validator(array('username' => 'tester', 'email' => 'test@test.com', 'nickname' => 'joseph'));
+        $v->rules(array(
+            'requiredWith' => array(
+                array('password', array('username', 'email', 'nickname'), true, true)
+            )
+        ));
+        $this->assertFalse($v->validate());
+    }
+
+    // required without tests
+
+    public function testRequiredWithoutCheckBooleanValid()
+    {
+        $v = new Validator(array('password' => 'mypassword'));
+        $v->rule('requiredWithout', 'password', 'username', false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanInvalidNotPresent()
+    {
+        $v = new Validator(array());
+        $v->rule('requiredWithout', 'password', 'username', false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanValidEmptyString()
+    {
+        $v = new Validator(array('username' => '', 'password' => 'mypassword'));
+        $v->rule('requiredWithout', 'password', 'username', false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanInvalidEmptyStringNotPresent()
+    {
+        $v = new Validator(array('username' => ''));
+        $v->rule('requiredWithout', 'password', 'username', false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanValidNullValue()
+    {
+        $v = new Validator(array('username' => null, 'password' => 'mypassword'));
+        $v->rule('requiredWithout', 'password', 'username', false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanInvlidNullValueNotPresent()
+    {
+        $v = new Validator(array('username' => null));
+        $v->rule('requiredWithout', 'password', 'username', false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanValidAltSyntax()
+    {
+        $v = new Validator(array('password' => 'mypassword'));
+        $v->rules(array(
+            'requiredWithout' => array(
+                array('password', 'username', false, true)
+            )
+        ));
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanInvalidAltSyntaxNotPresent()
+    {
+        $v = new Validator(array());
+        $v->rules(array(
+            'requiredWithout' => array(
+                array('password', 'username', false, true)
+            )
+        ));
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanValidArray()
+    {
+        $v = new Validator(array('password' => 'mypassword'));
+        $v->rule('requiredWithout', 'password', array('username', 'email'), false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanInvalidArrayNotPresent()
+    {
+        $v = new Validator(array());
+        $v->rule('requiredWithout', 'password', array('username', 'email'), false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanValidArrayPartial()
+    {
+        $v = new Validator(array('password' => 'mypassword', 'email' => 'test@test.com'));
+        $v->rule('requiredWithout', 'password', array('username', 'email'), false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanInvalidArrayPartial()
+    {
+        $v = new Validator(array('email' => 'test@test.com'));
+        $v->rule('requiredWithout', 'password', array('username', 'email'), false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanValidArrayStrict()
+    {
+        $v = new Validator(array('email' => 'test@test.com'));
+        $v->rule('requiredWithout', 'password', array('username', 'email'), true, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanInvalidArrayStrict()
+    {
+        $v = new Validator(array());
+        $v->rule('requiredWithout', 'password', array('username', 'email'), true, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanInvalidArrayNotProvided()
+    {
+        $v = new Validator(array('email' => 'test@test.com'));
+        $v->rule('requiredWithout', 'password', array('username', 'email'), false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanValidArrayAltSyntax()
+    {
+        $v = new Validator(array('password' => 'mypassword'));
+        $v->rules(array(
+            'requiredWithout' => array(
+                array('password', array('username', 'email'), false, true)
+            )
+        ));
+        $this->assertTrue($v->validate());
+    }
+
+    
+    // End Check boolean tests for requiredWith and requiredWithout
+
+    // Start new tests for $checkBool feature
+
+    // This test proves the new code (with $checkBool flag) treats (bool)false as "NOT set".
+    public function testRequiredWithCheckBooleanBoolFalseValid()
+    {
+        $v = new Validator(array('enabled' => false));
+        $v->rule('requiredWith', 'suffix', 'enabled', false, true);
+        $this->assertTrue($v->validate());
+    }
+
+    // This test proves the previous code (no $checkBool flag) treated (bool)false as "being set".
+    public function testRequiredWithCheckBooleanBoolFalseInvalid()
+    {
+        $v = new Validator(array('enabled' => false));
+        $v->rule('requiredWith', 'suffix', 'enabled', false, false);
+        $this->assertFalse($v->validate());
+    }
+
+    // These tests make the same assertions but test function with the Strict Flag.
+    public function testRequiredWithCheckBooleanStrictBoolFalseValid()
+    {
+        $v = new Validator(array('enabled' => false, 'hidden' => true));
+        $v->rule('requiredWith', 'suffix', ['enabled', 'hidden'], true, true);
+        $this->assertTrue($v->validate());
+    }
+
+    public function testRequiredWithCheckBooleanStrictBoolFalseInvalid()
+    {
+        $v = new Validator(array('enabled' => false, 'hidden' => true));
+        $v->rule('requiredWith', 'suffix', ['enabled', 'hidden'], true, false);
+        $this->assertFalse($v->validate());
+    }
+
+    // Next 4 tests, same as above, but for requiredWithout
+    public function testRequiredWithoutCheckBooleanBoolFalseValid()
+    {
+        $v = new Validator(array('is_adult' => false));
+        $v->rule('requiredWithout', 'mothers_name', 'is_adult', false, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanBoolFalseInvalid()
+    {
+        $v = new Validator(array('is_adult' => false));
+        $v->rule('requiredWithout', 'mothers_name', 'is_adult', false, false);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutCheckBooleanStrictDoubleBoolFalseInvalid()
+    {
+        // Strict requires both to NOT be set, one is set, so mothers_name is required.
+        // We are not providing mothers_name so this should assert false.
+        $v = new Validator(array('is_adult' => false, 'has_mother' => false));
+        $v->rule('requiredWithout', 'mothers_name', ['is_adult', 'has_mother'], true, true);
+        $this->assertFalse($v->validate());
+    }
+
+    public function testRequiredWithoutStrictDoubleBoolFalseInvalid()
+    {
+        // Strict requires both to NOT be set for mothers_name to be required.
+        // Check bool is not enabled, so these false values are treated as set per the previous code.
+        // For backwards compatibility, this should assert false since we are not providing mothers_name
+        $v = new Validator(array('is_adult' => false, 'has_mother' => false));
+        $v->rule('requiredWithout', 'mothers_name', ['is_adult', 'has_mother'], true, false);
+        $this->assertFalse($v->validate());
+    }
+
+    // End new tests for $checkBool
+    
+    
     public function testConditionallyRequiredAuthSampleToken()
     {
         $v = new Validator(array('token' => 'ajkdhieyf2834fsuhf8934y89'));


### PR DESCRIPTION
Adds `$checkBool` flag in the `requireWith` and `requireWithout` validators which increase the specificity check on the deterministic field(s) in order to correctly treat a value of (bool)false as "not set". When not enabled, the old behavior of treating (bool)false as "set" is maintained. The flag was added in order to maintain backward compatibility.

Full notes in commit log.