### PR TITLE
compatibility with php8.1

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -753,6 +753,9 @@ class Validator
      */
     protected function validateDate($field, $value)
     {
+        if ($value === null) {
+            return false;
+        }
         $isDate = false;
         if ($value instanceof \DateTime) {
             $isDate = true;

--- a/tests/Valitron/ValidateAddInstanceRuleTest.php
+++ b/tests/Valitron/ValidateAddInstanceRuleTest.php
@@ -115,6 +115,6 @@ class ValidateAddInstanceRuleTest extends BaseTestCase
         $v->addInstanceRule("foo_rule", function () {
         });
         $u = $v->getUniqueRuleName("foo");
-        $this->assertRegExp("/^foo_rule_[0-9]{1,5}$/", $u);
+        $this->assertMatchesRegularExpression("/^foo_rule_[0-9]{1,5}$/", $u);
     }
 }


### PR DESCRIPTION
1. changed method used in test to fix below warning
`1) ValidateAddInstanceRuleTest::testUniqueRuleName
assertRegExp() is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead.`
2. added early return for case of value being null to fix below warning
`Deprecated: strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated`