### PR TITLE
allow to override validationMustBeExecuted method and fix typo

### DIFF
--- a/src/Valitron/Validator.php
+++ b/src/Valitron/Validator.php
@@ -1195,7 +1195,8 @@ class Validator
         }
     }
 
-    private function validationMustBeExcecuted($validation, $field, $values, $multiple){
+    protected function validationMustBeExecuted($validation, $field, $values, $multiple)
+    {
         //always excecute requiredWith(out) rules
         if (in_array($validation['rule'], array('requiredWith', 'requiredWithout'))){
             return true;
@@ -1216,6 +1217,7 @@ class Validator
 
         return true;
     }
+
     /**
      * Run validations and return boolean result
      *
@@ -1228,7 +1230,7 @@ class Validator
             foreach ($v['fields'] as $field) {
                 list($values, $multiple) = $this->getPart($this->_fields, explode('.', $field), false);
 
-                if (! $this->validationMustBeExcecuted($v, $field, $values, $multiple)){
+                if (! $this->validationMustBeExecuted($v, $field, $values, $multiple)){
                     continue;
                 }
 


### PR DESCRIPTION
This PR:

1. Changes the visibility of validationMustBeExecuted method to be able to override it.
2. Fixes a typo in the method name